### PR TITLE
Draft: Fix panic on quick media state update

### DIFF
--- a/src/platform/dart/transceiver.rs
+++ b/src/platform/dart/transceiver.rs
@@ -125,15 +125,17 @@ impl Transceiver {
         &self,
         new_sender: Rc<local::Track>,
     ) -> Result<(), platform::Error> {
-        FutureFromDart::execute::<()>(unsafe {
+        let is_track_replaced = FutureFromDart::execute::<()>(unsafe {
             transceiver::replace_track(
                 self.transceiver.get(),
                 new_sender.platform_track().handle(),
             )
         })
         .await
-        .unwrap();
-        self.send_track.replace(Some(new_sender));
+        .is_ok();
+        if is_track_replaced {
+            self.send_track.replace(Some(new_sender));
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Synopsis

Этот PR фиксит панику происходящую при многократных и быстрых попытках включить/выключить публикацию видео/аудио.

Эта проблема связана с отключенным в версии для Flutter'а механизмом форков `MediaStreamTrack`'ов. Из-за этого при остановке форкнутого трека, также автоматически стопятся и треки, которые должны были быть независимыми от него, и из-за этого они имеют вероятность попасть в `Transceiver::replace_track` и привести к ошибке сообщающей о том, что мы пытаемся запихнуть дохлый трек в трансивера.


## Reproduce

1. Alice и Bob начинают звонок
2. Alice многократно и быстро выключает/включает видео много раз
3. Приложение падает с паникой на `Transceiver::replace_track`




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [ ] and approved
- [ ] [Review][l:2] is completed and changes are approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] `Draft: ` prefix is removed
    - [ ] All temporary labels are removed
    - [ ] `flutter-webrtc` dependency switched back to `master` branch





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests