### PR TITLE
Fix IceCandidate adding race condition bug

### DIFF
--- a/src/peer/component/ice_candidates.rs
+++ b/src/peer/component/ice_candidates.rs
@@ -2,7 +2,7 @@
 
 use std::{cell::RefCell, collections::HashSet};
 
-use futures::{stream, stream::LocalBoxStream};
+use futures::stream::{self, LocalBoxStream};
 use medea_client_api_proto::IceCandidate;
 use medea_reactive::ObservableHashSet;
 
@@ -31,8 +31,8 @@ impl IceCandidates {
         self.0.borrow_mut().insert(candidate);
     }
 
-    /// Returns [`LocalBoxStream`] with all already added [`IceCandidate`]s and
-    /// [`IceCandidate`]s which will be added in the future.
+    /// Returns [`LocalBoxStream`] with all the already added [`IceCandidate`]s
+    /// and the [`IceCandidate`]s which will be added in future.
     #[inline]
     pub fn on_add(&self) -> LocalBoxStream<'static, IceCandidate> {
         let this = self.0.borrow();


### PR DESCRIPTION
## Synopsis

Этот PR фиксит баг при котором обмен медиа данными не начинается после начала звонка. Как правило, баг проявляется на слабых устройствах и/или устройствах под высокой нагрузкой. Медиа не начинает идти, потому-что `IceCandidate`'ы успевают положиться в реактивный `HashSet` до того как на него подпишется компонент `PeerConnection`.

Для фикса бага нужно просто использовать специально созданную для этого функцию `replay_on_insert` и мерджить стрим из нее со стримом из `on_insert`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed
    - [x] `flutter-webrtc` dependency switched back to `master` branch





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests