### PR TITLE
Temporary disable broken E2E test (#24)

### DIFF
--- a/e2e/tests/features/state_synchronization.feature
+++ b/e2e/tests/features/state_synchronization.feature
@@ -35,13 +35,14 @@ Feature: State synchronization
     Then Alice has audio remote tracks from Bob
     And Bob has audio remote tracks from Alice
 
-  Scenario: Video endpoint added while disconnected
-    Given room with joined member Alice and Bob with no WebRTC endpoints
-    When Alice loses WS connection
-    And Control API interconnects video of Alice and Bob
-    And Alice restores WS connection
-    Then Alice has video remote tracks from Bob
-    And Bob has video remote tracks from Alice
+  # TODO(evdokimovs): this scenario randomly fails on CI, so it temporary disabled, but will be fixed in the future.
+  #  Scenario: Video endpoint added while disconnected
+  #    Given room with joined member Alice and Bob with no WebRTC endpoints
+  #    When Alice loses WS connection
+  #    And Control API interconnects video of Alice and Bob
+  #    And Alice restores WS connection
+  #    Then Alice has video remote tracks from Bob
+  #    And Bob has video remote tracks from Alice
 
   Scenario: New endpoint creates new tracks
     Given room with joined member Alice and Bob with no WebRTC endpoints


### PR DESCRIPTION
Part of #24

## Synopsis

E2E сценарий `Video endpoint added while disconnected` рандомно [падает на CI][1]. Эта проблема должна быть пофикшена в будущем, но на данный момент решено временно выключить этот тест, чтобы он не мешал релизить Jason и не мозолил глаза.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed
    - [x] `flutter-webrtc` dependency switched back to `master` branch





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
[1]: https://github.com/instrumentisto/medea-jason/runs/4883644669?check_suite_focus=true#step:12:839