### PR TITLE
Remove Default impl for Credentials

### DIFF
--- a/proto/control-api/src/control/member.rs
+++ b/proto/control-api/src/control/member.rs
@@ -253,12 +253,6 @@ impl Credentials {
     }
 }
 
-impl Default for Credentials {
-    fn default() -> Self {
-        Self::random()
-    }
-}
-
 /// Plain [`Credentials`] returned in a [`Sid`].
 #[derive(
     AsRef,


### PR DESCRIPTION
## Synopsis

Remove `Default` impl for `Credentials`, as it's not deterministic and may be a foot gun because of that.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed
  
[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests