### PR TITLE
Set `tonic_build::Builder::emit_rerun_if_changed(false)` to avoid rebuilding

### DIFF
--- a/proto/control-api/build.rs
+++ b/proto/control-api/build.rs
@@ -147,6 +147,7 @@ mod grpc {
                         || (cfg!(feature = "server")
                             && out.ends_with("api.rs")),
                 )
+                .emit_rerun_if_changed(false)
                 .compile(&[proto], &[GRPC_DIR.to_owned()])?;
         }
 


### PR DESCRIPTION
## Synopsis

Since `tonic-build 0.8` it automatically adds `cargo:rerun_if_changed`. This leads to constant  rebuilding of every crate that depends on `medea-control-api-proto`

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed
  
[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests