### PR TITLE
Async dispatch on `Command` emun

### DIFF
--- a/e2e-demo/index.html
+++ b/e2e-demo/index.html
@@ -1,15 +1,9 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
   <title>Medea E2E demo</title>
-  <script>
-    function goToCall() {
-      let roomId = document.getElementsByClassName('choose-room__id')[0].value;
-      document.location = "/video-call#" + roomId;
-    }
-  </script>
-
   <style>
     .choose-room {
       position: absolute;
@@ -29,9 +23,25 @@
     }
   </style>
 </head>
+
 <body>
-  <div class="choose-room">
+  <form class="choose-room">
     <input class="choose-room__id" placeholder="Room ID">
-    <button class="choose-room__join" onclick="goToCall()" type="submit">JOIN</button>
-  </div>
+    <button class="choose-room__join" type="submit">JOIN</button>
+  </form>
+
+  <script>
+    const formElement = document.querySelector(".choose-room");
+
+    if (formElement) {
+      formElement.addEventListener("submit", goToCall);
+    }
+
+    function goToCall(e) {
+      e.preventDefault();
+
+      let roomId = document.getElementsByClassName('choose-room__id')[0].value;
+      document.location = "/video-call#" + roomId;
+    }
+  </script>
 </body>

--- a/proto/client-api/src/lib.rs
+++ b/proto/client-api/src/lib.rs
@@ -237,7 +237,7 @@ pub struct RpcSettings {
 }
 
 /// Possible commands sent by Web Client to Media Server.
-#[dispatchable(self: &Self, async_trait(?Send))]
+#[dispatchable(self: &mut Self, async_trait(?Send))]
 #[allow(unused_results)] // false positive: on `Deserialize`
 #[cfg_attr(feature = "client", derive(Serialize))]
 #[cfg_attr(feature = "server", derive(Deserialize))]

--- a/proto/client-api/src/lib.rs
+++ b/proto/client-api/src/lib.rs
@@ -237,7 +237,7 @@ pub struct RpcSettings {
 }
 
 /// Possible commands sent by Web Client to Media Server.
-#[dispatchable]
+#[dispatchable(self: &Self, async_trait(?Send))]
 #[allow(unused_results)] // false positive: on `Deserialize`
 #[cfg_attr(feature = "client", derive(Serialize))]
 #[cfg_attr(feature = "server", derive(Deserialize))]


### PR DESCRIPTION
## Synopsis

Makes `Command` emun async dispatchable.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [ ] Documentation is updated (if required)
- [ ] Tests are updated (if required)
- [ ] Changes conform code style
- [ ] CHANGELOG entry is added (if required)
- [ ] FCM (final commit message) is posted
    - [ ] and approved
- [ ] [Review][l:2] is completed and changes are approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] `Draft: ` prefix is removed
    - [ ] All temporary labels are removed
  
[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests