### PR TITLE
Fix local track disposal race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
       - uses: arduino/setup-protoc@v1
         with:
           version: ${{ env.PROTOC_VER }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - run: make cargo.lint
 
@@ -188,6 +189,7 @@ jobs:
       - uses: arduino/setup-protoc@v1
         with:
           version: ${{ env.PROTOC_VER }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ steps.skip.outputs.no == 'true'
              && matrix.crate == 'medea-control-api-proto' }}
 
@@ -233,6 +235,7 @@ jobs:
       - uses: arduino/setup-protoc@v1
         with:
           version: ${{ env.PROTOC_VER }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: Swatinem/rust-cache@v2
         if: ${{ env.CACHE == 'true' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,9 +334,9 @@ checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "arc-swap"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
 name = "async-recursion"
@@ -582,7 +582,7 @@ dependencies = [
  "once_cell",
  "strsim",
  "termcolor",
- "terminal_size 0.2.3",
+ "terminal_size",
 ]
 
 [[package]]
@@ -630,16 +630,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
+checksum = "5556015fe3aad8b968e5d4124980fbe2f6aaee7aeec6b749de1faaa2ca5d0a4c"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "terminal_size 0.1.17",
  "unicode-width",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -744,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "cucumber"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f0a8148f50395243f5e93d39893a6d8e3449097501ccd97c162967dfe8877c"
+checksum = "a845da7c9fb958144700201d22e3f61f55114f9e269c13f03fe179d9da500984"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -775,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "cucumber-codegen"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d10b08005214a8119b331a362822e17b2bcfdf0944f5854120a81f6b939ec96a"
+checksum = "0dfb841fe8742f57fbe94738a189022e7dc858f2560c7fba5da44dc945a139e1"
 dependencies = [
  "cucumber-expressions",
  "inflections",
@@ -1942,9 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.1"
+version = "7.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -2007,9 +2006,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "openssl"
@@ -2180,9 +2179,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "predicates"
-version = "2.1.4"
+version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54fc5dc63ed3bbf19494623db4f3af16842c0d975818e469022d09e53f0aa05"
+checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
 dependencies = [
  "difflib",
  "float-cmp",
@@ -2474,9 +2473,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.5"
+version = "0.36.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
+checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
 dependencies = [
  "bitflags",
  "errno",
@@ -2970,16 +2969,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ wasm-bindgen-futures = "0.4"
 wasm-logger = "0.2"
 wee_alloc = { version = "0.4", optional = true }
 [target.'cfg(target_family = "wasm")'.dependencies.web-sys]
-    version = "0.3.47"
+    version = "0.3.60"
     features = [
         "console",
         "ConstrainDomStringParameters", "ConstrainDoubleRange",

--- a/flutter/example/integration_test/jason.dart
+++ b/flutter/example/integration_test/jason.dart
@@ -67,7 +67,7 @@ void main() {
     expect(tracks.first.kind(), equals(MediaKind.Video));
     expect(tracks.first.mediaSourceKind(), equals(MediaSourceKind.Display));
 
-    tracks.first.free();
+    await tracks.first.free();
     expect(() => tracks.first.kind(), throwsStateError);
 
     expect(
@@ -287,7 +287,7 @@ void main() {
     await Future.wait(allFired.map((e) => e.future))
         .timeout(Duration(seconds: 1));
 
-    track.free();
+    await track.free();
     expect(() => track.kind(), throwsStateError);
   });
 

--- a/flutter/example/pubspec.lock
+++ b/flutter/example/pubspec.lock
@@ -277,7 +277,7 @@ packages:
       name: medea_flutter_webrtc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.0-dev+rev.0ef956e098dfe3ef20c108e6b60ca5f285310409"
+    version: "0.8.0-dev+rev.39f8181e33a20db445d16c1bfedd7d337a777fe3"
   medea_jason:
     dependency: "direct main"
     description:

--- a/flutter/example/pubspec.lock
+++ b/flutter/example/pubspec.lock
@@ -277,7 +277,7 @@ packages:
       name: medea_flutter_webrtc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.0-dev+rev.39f8181e33a20db445d16c1bfedd7d337a777fe3"
+    version: "0.8.0-dev+rev.0ef956e098dfe3ef20c108e6b60ca5f285310409"
   medea_jason:
     dependency: "direct main"
     description:

--- a/flutter/lib/src/interface/audio_track_constraints.dart
+++ b/flutter/lib/src/interface/audio_track_constraints.dart
@@ -1,7 +1,7 @@
 import '/src/util/rust_handles_storage.dart';
 
 /// Constraints applicable to audio tracks.
-abstract class AudioTrackConstraints extends SyncPlatformHandle {
+abstract class AudioTrackConstraints implements SyncPlatformHandle {
   /// Sets an exact [`deviceId`][1] constraint.
   ///
   /// [1]: https://w3.org/TR/mediacapture-streams#def-constraint-deviceId

--- a/flutter/lib/src/interface/audio_track_constraints.dart
+++ b/flutter/lib/src/interface/audio_track_constraints.dart
@@ -1,7 +1,7 @@
 import '/src/util/rust_handles_storage.dart';
 
 /// Constraints applicable to audio tracks.
-abstract class AudioTrackConstraints implements SyncPlatformHandle {
+abstract class AudioTrackConstraints extends SyncPlatformHandle {
   /// Sets an exact [`deviceId`][1] constraint.
   ///
   /// [1]: https://w3.org/TR/mediacapture-streams#def-constraint-deviceId

--- a/flutter/lib/src/interface/audio_track_constraints.dart
+++ b/flutter/lib/src/interface/audio_track_constraints.dart
@@ -1,7 +1,7 @@
 import '/src/util/rust_handles_storage.dart';
 
 /// Constraints applicable to audio tracks.
-abstract class AudioTrackConstraints implements PlatformHandle {
+abstract class AudioTrackConstraints implements SyncPlatformHandle {
   /// Sets an exact [`deviceId`][1] constraint.
   ///
   /// [1]: https://w3.org/TR/mediacapture-streams#def-constraint-deviceId

--- a/flutter/lib/src/interface/connection_handle.dart
+++ b/flutter/lib/src/interface/connection_handle.dart
@@ -2,7 +2,7 @@ import '/src/util/rust_handles_storage.dart';
 import 'media_track.dart';
 
 /// External handler to a `Connection` with a remote `Member`.
-abstract class ConnectionHandle implements SyncPlatformHandle {
+abstract class ConnectionHandle extends SyncPlatformHandle {
   /// Returns ID of the remote `Member`.
   ///
   /// Throws a [StateError] if an underlying object has been disposed, e.g.

--- a/flutter/lib/src/interface/connection_handle.dart
+++ b/flutter/lib/src/interface/connection_handle.dart
@@ -2,7 +2,7 @@ import '/src/util/rust_handles_storage.dart';
 import 'media_track.dart';
 
 /// External handler to a `Connection` with a remote `Member`.
-abstract class ConnectionHandle implements PlatformHandle {
+abstract class ConnectionHandle implements SyncPlatformHandle {
   /// Returns ID of the remote `Member`.
   ///
   /// Throws a [StateError] if an underlying object has been disposed, e.g.

--- a/flutter/lib/src/interface/connection_handle.dart
+++ b/flutter/lib/src/interface/connection_handle.dart
@@ -2,7 +2,7 @@ import '/src/util/rust_handles_storage.dart';
 import 'media_track.dart';
 
 /// External handler to a `Connection` with a remote `Member`.
-abstract class ConnectionHandle extends SyncPlatformHandle {
+abstract class ConnectionHandle implements SyncPlatformHandle {
   /// Returns ID of the remote `Member`.
   ///
   /// Throws a [StateError] if an underlying object has been disposed, e.g.

--- a/flutter/lib/src/interface/device_video_track_constraints.dart
+++ b/flutter/lib/src/interface/device_video_track_constraints.dart
@@ -20,7 +20,7 @@ enum FacingMode {
   Right,
 }
 
-abstract class DeviceVideoTrackConstraints implements PlatformHandle {
+abstract class DeviceVideoTrackConstraints implements SyncPlatformHandle {
   /// Sets an exact [`deviceId`][1] constraint.
   ///
   /// [1]: https://w3.org/TR/mediacapture-streams#def-constraint-deviceId

--- a/flutter/lib/src/interface/device_video_track_constraints.dart
+++ b/flutter/lib/src/interface/device_video_track_constraints.dart
@@ -20,7 +20,7 @@ enum FacingMode {
   Right,
 }
 
-abstract class DeviceVideoTrackConstraints implements SyncPlatformHandle {
+abstract class DeviceVideoTrackConstraints extends SyncPlatformHandle {
   /// Sets an exact [`deviceId`][1] constraint.
   ///
   /// [1]: https://w3.org/TR/mediacapture-streams#def-constraint-deviceId

--- a/flutter/lib/src/interface/device_video_track_constraints.dart
+++ b/flutter/lib/src/interface/device_video_track_constraints.dart
@@ -20,7 +20,7 @@ enum FacingMode {
   Right,
 }
 
-abstract class DeviceVideoTrackConstraints extends SyncPlatformHandle {
+abstract class DeviceVideoTrackConstraints implements SyncPlatformHandle {
   /// Sets an exact [`deviceId`][1] constraint.
   ///
   /// [1]: https://w3.org/TR/mediacapture-streams#def-constraint-deviceId

--- a/flutter/lib/src/interface/display_video_track_constraints.dart
+++ b/flutter/lib/src/interface/display_video_track_constraints.dart
@@ -1,7 +1,7 @@
 import '/src/util/rust_handles_storage.dart';
 
 /// Constraints applicable to video tracks sourced from a screen capturing.
-abstract class DisplayVideoTrackConstraints implements PlatformHandle {
+abstract class DisplayVideoTrackConstraints implements SyncPlatformHandle {
   /// Sets an exact [`height`][1] constraint.
   ///
   /// Converts the provided [height] into an `u32`. Throws an [ArgumentError] if

--- a/flutter/lib/src/interface/display_video_track_constraints.dart
+++ b/flutter/lib/src/interface/display_video_track_constraints.dart
@@ -1,7 +1,7 @@
 import '/src/util/rust_handles_storage.dart';
 
 /// Constraints applicable to video tracks sourced from a screen capturing.
-abstract class DisplayVideoTrackConstraints extends SyncPlatformHandle {
+abstract class DisplayVideoTrackConstraints implements SyncPlatformHandle {
   /// Sets an exact [`height`][1] constraint.
   ///
   /// Converts the provided [height] into an `u32`. Throws an [ArgumentError] if

--- a/flutter/lib/src/interface/display_video_track_constraints.dart
+++ b/flutter/lib/src/interface/display_video_track_constraints.dart
@@ -1,7 +1,7 @@
 import '/src/util/rust_handles_storage.dart';
 
 /// Constraints applicable to video tracks sourced from a screen capturing.
-abstract class DisplayVideoTrackConstraints implements SyncPlatformHandle {
+abstract class DisplayVideoTrackConstraints extends SyncPlatformHandle {
   /// Sets an exact [`height`][1] constraint.
   ///
   /// Converts the provided [height] into an `u32`. Throws an [ArgumentError] if

--- a/flutter/lib/src/interface/jason.dart
+++ b/flutter/lib/src/interface/jason.dart
@@ -7,7 +7,7 @@ import 'room_handle.dart';
 ///
 /// Responsible for managing shared transports, local media and room
 /// initialization.
-abstract class Jason extends SyncPlatformHandle {
+abstract class Jason implements SyncPlatformHandle {
   /// Returns a [MediaManagerHandle] to the `MediaManager` of this [Jason].
   MediaManagerHandle mediaManager();
 

--- a/flutter/lib/src/interface/jason.dart
+++ b/flutter/lib/src/interface/jason.dart
@@ -7,7 +7,7 @@ import 'room_handle.dart';
 ///
 /// Responsible for managing shared transports, local media and room
 /// initialization.
-abstract class Jason implements PlatformHandle {
+abstract class Jason implements SyncPlatformHandle {
   /// Returns a [MediaManagerHandle] to the `MediaManager` of this [Jason].
   MediaManagerHandle mediaManager();
 

--- a/flutter/lib/src/interface/jason.dart
+++ b/flutter/lib/src/interface/jason.dart
@@ -7,7 +7,7 @@ import 'room_handle.dart';
 ///
 /// Responsible for managing shared transports, local media and room
 /// initialization.
-abstract class Jason implements SyncPlatformHandle {
+abstract class Jason extends SyncPlatformHandle {
   /// Returns a [MediaManagerHandle] to the `MediaManager` of this [Jason].
   MediaManagerHandle mediaManager();
 

--- a/flutter/lib/src/interface/media_device_info.dart
+++ b/flutter/lib/src/interface/media_device_info.dart
@@ -15,7 +15,7 @@ enum MediaDeviceKind {
 /// [`MediaDeviceInfo`][1] interface.
 ///
 /// [1]: https://w3.org/TR/mediacapture-streams#device-info
-abstract class MediaDeviceInfo implements PlatformHandle {
+abstract class MediaDeviceInfo implements SyncPlatformHandle {
   /// Returns an unique identifier of the represented device.
   String deviceId();
 

--- a/flutter/lib/src/interface/media_device_info.dart
+++ b/flutter/lib/src/interface/media_device_info.dart
@@ -15,7 +15,7 @@ enum MediaDeviceKind {
 /// [`MediaDeviceInfo`][1] interface.
 ///
 /// [1]: https://w3.org/TR/mediacapture-streams#device-info
-abstract class MediaDeviceInfo implements SyncPlatformHandle {
+abstract class MediaDeviceInfo extends SyncPlatformHandle {
   /// Returns an unique identifier of the represented device.
   String deviceId();
 

--- a/flutter/lib/src/interface/media_device_info.dart
+++ b/flutter/lib/src/interface/media_device_info.dart
@@ -15,7 +15,7 @@ enum MediaDeviceKind {
 /// [`MediaDeviceInfo`][1] interface.
 ///
 /// [1]: https://w3.org/TR/mediacapture-streams#device-info
-abstract class MediaDeviceInfo extends SyncPlatformHandle {
+abstract class MediaDeviceInfo implements SyncPlatformHandle {
   /// Returns an unique identifier of the represented device.
   String deviceId();
 

--- a/flutter/lib/src/interface/media_display_info.dart
+++ b/flutter/lib/src/interface/media_display_info.dart
@@ -1,7 +1,7 @@
 import '/src/util/rust_handles_storage.dart';
 
 /// [`MediaDisplayInfo`] interface.
-abstract class MediaDisplayInfo implements SyncPlatformHandle {
+abstract class MediaDisplayInfo extends SyncPlatformHandle {
   /// Returns a unique identifier of the represented display.
   String deviceId();
 

--- a/flutter/lib/src/interface/media_display_info.dart
+++ b/flutter/lib/src/interface/media_display_info.dart
@@ -1,7 +1,7 @@
 import '/src/util/rust_handles_storage.dart';
 
 /// [`MediaDisplayInfo`] interface.
-abstract class MediaDisplayInfo extends SyncPlatformHandle {
+abstract class MediaDisplayInfo implements SyncPlatformHandle {
   /// Returns a unique identifier of the represented display.
   String deviceId();
 

--- a/flutter/lib/src/interface/media_display_info.dart
+++ b/flutter/lib/src/interface/media_display_info.dart
@@ -1,7 +1,7 @@
 import '/src/util/rust_handles_storage.dart';
 
 /// [`MediaDisplayInfo`] interface.
-abstract class MediaDisplayInfo implements PlatformHandle {
+abstract class MediaDisplayInfo implements SyncPlatformHandle {
   /// Returns a unique identifier of the represented display.
   String deviceId();
 

--- a/flutter/lib/src/interface/media_manager.dart
+++ b/flutter/lib/src/interface/media_manager.dart
@@ -12,7 +12,7 @@ import 'media_track.dart';
 ///
 /// [1]: https://w3.org/TR/mediacapture-streams#dom-mediadevices-getusermedia
 /// [2]: https://w3.org/TR/screen-capture#dom-mediadevices-getdisplaymedia
-abstract class MediaManagerHandle implements PlatformHandle {
+abstract class MediaManagerHandle implements SyncPlatformHandle {
   /// Obtains [LocalMediaTrack]s objects from local media devices (or screen
   /// capture) basing on the provided [MediaStreamSettings].
   ///

--- a/flutter/lib/src/interface/media_manager.dart
+++ b/flutter/lib/src/interface/media_manager.dart
@@ -12,7 +12,7 @@ import 'media_track.dart';
 ///
 /// [1]: https://w3.org/TR/mediacapture-streams#dom-mediadevices-getusermedia
 /// [2]: https://w3.org/TR/screen-capture#dom-mediadevices-getdisplaymedia
-abstract class MediaManagerHandle implements SyncPlatformHandle {
+abstract class MediaManagerHandle extends SyncPlatformHandle {
   /// Obtains [LocalMediaTrack]s objects from local media devices (or screen
   /// capture) basing on the provided [MediaStreamSettings].
   ///

--- a/flutter/lib/src/interface/media_manager.dart
+++ b/flutter/lib/src/interface/media_manager.dart
@@ -12,7 +12,7 @@ import 'media_track.dart';
 ///
 /// [1]: https://w3.org/TR/mediacapture-streams#dom-mediadevices-getusermedia
 /// [2]: https://w3.org/TR/screen-capture#dom-mediadevices-getdisplaymedia
-abstract class MediaManagerHandle extends SyncPlatformHandle {
+abstract class MediaManagerHandle implements SyncPlatformHandle {
   /// Obtains [LocalMediaTrack]s objects from local media devices (or screen
   /// capture) basing on the provided [MediaStreamSettings].
   ///

--- a/flutter/lib/src/interface/media_stream_settings.dart
+++ b/flutter/lib/src/interface/media_stream_settings.dart
@@ -7,7 +7,7 @@ import 'display_video_track_constraints.dart';
 /// Representation of [`MediaStreamConstraints`][1].
 ///
 /// [1]: https://w3.org/TR/mediacapture-streams#dom-mediastreamconstraints
-abstract class MediaStreamSettings extends SyncPlatformHandle {
+abstract class MediaStreamSettings implements SyncPlatformHandle {
   /// Specifies a nature and settings of the audio `LocalMediaTrack`.
   void audio(@moveSemantics AudioTrackConstraints constraints);
 

--- a/flutter/lib/src/interface/media_stream_settings.dart
+++ b/flutter/lib/src/interface/media_stream_settings.dart
@@ -7,7 +7,7 @@ import 'display_video_track_constraints.dart';
 /// Representation of [`MediaStreamConstraints`][1].
 ///
 /// [1]: https://w3.org/TR/mediacapture-streams#dom-mediastreamconstraints
-abstract class MediaStreamSettings implements PlatformHandle {
+abstract class MediaStreamSettings implements SyncPlatformHandle {
   /// Specifies a nature and settings of the audio `LocalMediaTrack`.
   void audio(@moveSemantics AudioTrackConstraints constraints);
 

--- a/flutter/lib/src/interface/media_stream_settings.dart
+++ b/flutter/lib/src/interface/media_stream_settings.dart
@@ -7,7 +7,7 @@ import 'display_video_track_constraints.dart';
 /// Representation of [`MediaStreamConstraints`][1].
 ///
 /// [1]: https://w3.org/TR/mediacapture-streams#dom-mediastreamconstraints
-abstract class MediaStreamSettings implements SyncPlatformHandle {
+abstract class MediaStreamSettings extends SyncPlatformHandle {
   /// Specifies a nature and settings of the audio `LocalMediaTrack`.
   void audio(@moveSemantics AudioTrackConstraints constraints);
 

--- a/flutter/lib/src/interface/media_track.dart
+++ b/flutter/lib/src/interface/media_track.dart
@@ -38,7 +38,7 @@ enum TrackMediaDirection {
 }
 
 /// Abstraction of a handle to an object allocated on the Rust side.
-abstract class MediaTrack implements PlatformHandle {
+abstract class MediaTrack implements AsyncPlatformHandle {
   /// Returns the [MediaKind.Audio] if this [LocalMediaTrack] represents an
   /// audio track, or the [MediaKind.Video] if it represents a video track.
   MediaKind kind();

--- a/flutter/lib/src/interface/media_track.dart
+++ b/flutter/lib/src/interface/media_track.dart
@@ -38,7 +38,7 @@ enum TrackMediaDirection {
 }
 
 /// Abstraction of a handle to an object allocated on the Rust side.
-abstract class MediaTrack extends AsyncPlatformHandle {
+abstract class MediaTrack implements AsyncPlatformHandle {
   /// Returns the [MediaKind.Audio] if this [LocalMediaTrack] represents an
   /// audio track, or the [MediaKind.Video] if it represents a video track.
   MediaKind kind();

--- a/flutter/lib/src/interface/media_track.dart
+++ b/flutter/lib/src/interface/media_track.dart
@@ -38,7 +38,7 @@ enum TrackMediaDirection {
 }
 
 /// Abstraction of a handle to an object allocated on the Rust side.
-abstract class MediaTrack implements AsyncPlatformHandle {
+abstract class MediaTrack extends AsyncPlatformHandle {
   /// Returns the [MediaKind.Audio] if this [LocalMediaTrack] represents an
   /// audio track, or the [MediaKind.Video] if it represents a video track.
   MediaKind kind();

--- a/flutter/lib/src/interface/reconnect_handle.dart
+++ b/flutter/lib/src/interface/reconnect_handle.dart
@@ -3,7 +3,7 @@ import '/src/util/rust_handles_storage.dart';
 /// External handle used to reconnect to a media server when connection is lost.
 ///
 /// This handle is passed to the `RoomHandle.onConnectionLoss()` callback.
-abstract class ReconnectHandle extends SyncPlatformHandle {
+abstract class ReconnectHandle implements SyncPlatformHandle {
   /// Tries to reconnect a `Room` after the provided delay in milliseconds.
   ///
   /// If the `Room` is already reconnecting then new reconnection attempt won't

--- a/flutter/lib/src/interface/reconnect_handle.dart
+++ b/flutter/lib/src/interface/reconnect_handle.dart
@@ -3,7 +3,7 @@ import '/src/util/rust_handles_storage.dart';
 /// External handle used to reconnect to a media server when connection is lost.
 ///
 /// This handle is passed to the `RoomHandle.onConnectionLoss()` callback.
-abstract class ReconnectHandle implements PlatformHandle {
+abstract class ReconnectHandle implements SyncPlatformHandle {
   /// Tries to reconnect a `Room` after the provided delay in milliseconds.
   ///
   /// If the `Room` is already reconnecting then new reconnection attempt won't

--- a/flutter/lib/src/interface/reconnect_handle.dart
+++ b/flutter/lib/src/interface/reconnect_handle.dart
@@ -3,7 +3,7 @@ import '/src/util/rust_handles_storage.dart';
 /// External handle used to reconnect to a media server when connection is lost.
 ///
 /// This handle is passed to the `RoomHandle.onConnectionLoss()` callback.
-abstract class ReconnectHandle implements SyncPlatformHandle {
+abstract class ReconnectHandle extends SyncPlatformHandle {
   /// Tries to reconnect a `Room` after the provided delay in milliseconds.
   ///
   /// If the `Room` is already reconnecting then new reconnection attempt won't

--- a/flutter/lib/src/interface/room_close_reason.dart
+++ b/flutter/lib/src/interface/room_close_reason.dart
@@ -3,7 +3,7 @@ import '/src/util/rust_handles_storage.dart';
 /// Reason of why a `Room` has been closed.
 ///
 /// This struct is passed into the `RoomHandle.onClose()` callback.
-abstract class RoomCloseReason implements PlatformHandle {
+abstract class RoomCloseReason implements SyncPlatformHandle {
   /// Returns a close reason of the `Room`.
   String reason();
 

--- a/flutter/lib/src/interface/room_close_reason.dart
+++ b/flutter/lib/src/interface/room_close_reason.dart
@@ -3,7 +3,7 @@ import '/src/util/rust_handles_storage.dart';
 /// Reason of why a `Room` has been closed.
 ///
 /// This struct is passed into the `RoomHandle.onClose()` callback.
-abstract class RoomCloseReason implements SyncPlatformHandle {
+abstract class RoomCloseReason extends SyncPlatformHandle {
   /// Returns a close reason of the `Room`.
   String reason();
 

--- a/flutter/lib/src/interface/room_close_reason.dart
+++ b/flutter/lib/src/interface/room_close_reason.dart
@@ -3,7 +3,7 @@ import '/src/util/rust_handles_storage.dart';
 /// Reason of why a `Room` has been closed.
 ///
 /// This struct is passed into the `RoomHandle.onClose()` callback.
-abstract class RoomCloseReason extends SyncPlatformHandle {
+abstract class RoomCloseReason implements SyncPlatformHandle {
   /// Returns a close reason of the `Room`.
   String reason();
 

--- a/flutter/lib/src/interface/room_handle.dart
+++ b/flutter/lib/src/interface/room_handle.dart
@@ -6,7 +6,7 @@ import 'reconnect_handle.dart';
 import 'room_close_reason.dart';
 
 /// External handle to a `Room`.
-abstract class RoomHandle implements PlatformHandle {
+abstract class RoomHandle implements SyncPlatformHandle {
   /// Connects to a media server and joins the `Room` with the provided
   /// authorization [token].
   ///

--- a/flutter/lib/src/interface/room_handle.dart
+++ b/flutter/lib/src/interface/room_handle.dart
@@ -6,7 +6,7 @@ import 'reconnect_handle.dart';
 import 'room_close_reason.dart';
 
 /// External handle to a `Room`.
-abstract class RoomHandle extends SyncPlatformHandle {
+abstract class RoomHandle implements SyncPlatformHandle {
   /// Connects to a media server and joins the `Room` with the provided
   /// authorization [token].
   ///

--- a/flutter/lib/src/interface/room_handle.dart
+++ b/flutter/lib/src/interface/room_handle.dart
@@ -6,7 +6,7 @@ import 'reconnect_handle.dart';
 import 'room_close_reason.dart';
 
 /// External handle to a `Room`.
-abstract class RoomHandle implements SyncPlatformHandle {
+abstract class RoomHandle extends SyncPlatformHandle {
   /// Connects to a media server and joins the `Room` with the provided
   /// authorization [token].
   ///

--- a/flutter/lib/src/native/audio_track_constraints.dart
+++ b/flutter/lib/src/native/audio_track_constraints.dart
@@ -27,7 +27,7 @@ final _deviceId = dl.lookupFunction<_deviceId_C, _deviceId_Dart>(
 final _free =
     dl.lookupFunction<_free_C, _free_Dart>('AudioTrackConstraints__free');
 
-class AudioTrackConstraints extends base.AudioTrackConstraints {
+class AudioTrackConstraints implements base.AudioTrackConstraints {
   /// [Pointer] to the Rust struct backing this object.
   final NullablePointer ptr = NullablePointer(_new());
 

--- a/flutter/lib/src/native/connection_handle.dart
+++ b/flutter/lib/src/native/connection_handle.dart
@@ -72,7 +72,7 @@ final _enableRemoteVideo =
     dl.lookupFunction<_enableRemoteVideo_C, _enableRemoteVideo_Dart>(
         'ConnectionHandle__enable_remote_video');
 
-class NativeConnectionHandle extends ConnectionHandle {
+class NativeConnectionHandle implements ConnectionHandle {
   /// [Pointer] to the Rust struct backing this object.
   late NullablePointer ptr;
 

--- a/flutter/lib/src/native/device_video_track_constraints.dart
+++ b/flutter/lib/src/native/device_video_track_constraints.dart
@@ -77,7 +77,7 @@ final _widthInRange = dl.lookupFunction<_widthInRange_C, _widthInRange_Dart>(
 final _free =
     dl.lookupFunction<_free_C, _free_Dart>('DeviceVideoTrackConstraints__free');
 
-class DeviceVideoTrackConstraints extends base.DeviceVideoTrackConstraints {
+class DeviceVideoTrackConstraints implements base.DeviceVideoTrackConstraints {
   /// [Pointer] to the Rust struct backing this object.
   final NullablePointer ptr = NullablePointer(_new());
 

--- a/flutter/lib/src/native/display_video_track_constraints.dart
+++ b/flutter/lib/src/native/display_video_track_constraints.dart
@@ -65,7 +65,8 @@ final _deviceId = dl.lookupFunction<_deviceId_C, _deviceId_Dart>(
 final _free_Dart _free = dl
     .lookupFunction<_free_C, _free_Dart>('DisplayVideoTrackConstraints__free');
 
-class DisplayVideoTrackConstraints extends base.DisplayVideoTrackConstraints {
+class DisplayVideoTrackConstraints
+    implements base.DisplayVideoTrackConstraints {
   /// [Pointer] to the Rust struct backing this object.
   final NullablePointer ptr = NullablePointer(_new());
 

--- a/flutter/lib/src/native/ffi/exception.dart
+++ b/flutter/lib/src/native/ffi/exception.dart
@@ -135,8 +135,8 @@ class NativePanicException implements Exception {
 }
 
 /// Exception thrown when local media acquisition fails.
-class NativeLocalMediaInitException extends LocalMediaInitException
-    implements Exception {
+class NativeLocalMediaInitException
+    implements LocalMediaInitException, Exception {
   /// Concrete error kind of this [NativeLocalMediaInitException].
   late final LocalMediaInitExceptionKind _kind;
 
@@ -177,8 +177,8 @@ class NativeLocalMediaInitException extends LocalMediaInitException
 /// Exception thrown when cannot get info about connected [MediaDevices][1].
 ///
 /// [1]: https://w3.org/TR/mediacapture-streams#mediadevices
-class NativeEnumerateDevicesException extends EnumerateDevicesException
-    implements Exception {
+class NativeEnumerateDevicesException
+    implements EnumerateDevicesException, Exception {
   /// Dart [Exception] or [Error] that caused this [NativeEnumerateDevicesException].
   late final Object _cause;
 
@@ -201,7 +201,7 @@ class NativeEnumerateDevicesException extends EnumerateDevicesException
 
 /// Exception thrown when cannot switch audio output device ID.
 class NativeInvalidOutputAudioDeviceIdException
-    extends InvalidOutputAudioDeviceIdException {
+    implements InvalidOutputAudioDeviceIdException {
   /// Native stacktrace.
   late final String _nativeStackTrace;
 
@@ -215,7 +215,7 @@ class NativeInvalidOutputAudioDeviceIdException
 }
 
 /// Exception thrown when cannot interact with microphone volume.
-class NativeMicVolumeException extends MicVolumeException {
+class NativeMicVolumeException implements MicVolumeException {
   /// Dart [Exception] or [Error] that caused this [NativeMicVolumeException].
   late final Object _cause;
 
@@ -238,7 +238,7 @@ class NativeMicVolumeException extends MicVolumeException {
 
 /// Exceptions thrown from `Jason`'s `RpcClient` which implements messaging with
 /// media server.
-class NativeRpcClientException extends RpcClientException implements Exception {
+class NativeRpcClientException implements RpcClientException, Exception {
   /// Concrete error kind of this [NativeRpcClientException].
   late final RpcClientExceptionKind _kind;
 
@@ -278,8 +278,8 @@ class NativeRpcClientException extends RpcClientException implements Exception {
 
 /// Exception thrown when the requested media state transition could not be
 /// performed.
-class NativeMediaStateTransitionException extends MediaStateTransitionException
-    implements Exception {
+class NativeMediaStateTransitionException
+    implements MediaStateTransitionException, Exception {
   /// Error message describing the problem.
   late final String _message;
 
@@ -313,7 +313,7 @@ class NativeMediaStateTransitionException extends MediaStateTransitionException
 ///
 /// This is either a programmatic error or some unexpected platform component
 /// failure that cannot be handled in any way.
-class NativeInternalException extends InternalException implements Exception {
+class NativeInternalException implements InternalException, Exception {
   /// Error message describing the problem.
   late final String _message;
 
@@ -344,8 +344,8 @@ class NativeInternalException extends InternalException implements Exception {
 
 /// Exception that might happen when updating local media settings via
 /// `RoomHandle.setLocalMediaSettings`.
-class NativeMediaSettingsUpdateException extends MediaSettingsUpdateException
-    implements Exception {
+class NativeMediaSettingsUpdateException
+    implements MediaSettingsUpdateException, Exception {
   /// Error message describing the problem.
   late final String _message;
 

--- a/flutter/lib/src/native/jason.dart
+++ b/flutter/lib/src/native/jason.dart
@@ -116,9 +116,9 @@ DynamicLibrary _dl_load() {
   executor = Executor(dl);
 
   final _onPanic = dl.lookupFunction<_onPanic_C, _onPanic_Dart>('on_panic');
-  _onPanic((msg) {
+  _onPanic((msg) async {
     msg as String;
-    RustHandlesStorage().freeAll();
+    await RustHandlesStorage().freeAll();
     if (_onPanicCallback != null) {
       _onPanicCallback!(msg);
     }

--- a/flutter/lib/src/native/jason.dart
+++ b/flutter/lib/src/native/jason.dart
@@ -127,7 +127,7 @@ DynamicLibrary _dl_load() {
   return dl;
 }
 
-class Jason extends base.Jason {
+class Jason implements base.Jason {
   /// [Pointer] to the Rust struct backing this object.
   final NullablePointer ptr = NullablePointer(_new());
 

--- a/flutter/lib/src/native/local_media_track.dart
+++ b/flutter/lib/src/native/local_media_track.dart
@@ -31,7 +31,7 @@ final _getTrack = dl
 
 final _free = dl.lookupFunction<_free_C, _free_Dart>('LocalMediaTrack__free');
 
-class NativeLocalMediaTrack extends LocalMediaTrack {
+class NativeLocalMediaTrack implements LocalMediaTrack {
   /// [Pointer] to the Rust struct backing this object.
   late NullablePointer ptr;
 
@@ -63,8 +63,9 @@ class NativeLocalMediaTrack extends LocalMediaTrack {
   Future<void> free() async {
     if (!ptr.isFreed()) {
       RustHandlesStorage().removeHandle(this);
-      await (_free(ptr.getInnerPtr()) as Future);
+      var innerPtr = ptr.getInnerPtr();
       ptr.free();
+      await (_free(innerPtr) as Future);
     }
   }
 }

--- a/flutter/lib/src/native/local_media_track.dart
+++ b/flutter/lib/src/native/local_media_track.dart
@@ -17,8 +17,8 @@ typedef _mediaSourceKind_Dart = int Function(Pointer);
 typedef _getTrack_C = Handle Function(Pointer);
 typedef _getTrack_Dart = Object Function(Pointer);
 
-typedef _free_C = Void Function(Pointer);
-typedef _free_Dart = void Function(Pointer);
+typedef _free_C = Handle Function(Pointer);
+typedef _free_Dart = Object Function(Pointer);
 
 final _kind = dl.lookupFunction<_kind_C, _kind_Dart>('LocalMediaTrack__kind');
 
@@ -60,10 +60,10 @@ class NativeLocalMediaTrack extends LocalMediaTrack {
 
   @moveSemantics
   @override
-  void free() {
+  Future<void> free() async {
     if (!ptr.isFreed()) {
       RustHandlesStorage().removeHandle(this);
-      _free(ptr.getInnerPtr());
+      await (_free(ptr.getInnerPtr()) as Future);
       ptr.free();
     }
   }

--- a/flutter/lib/src/native/media_device_info.dart
+++ b/flutter/lib/src/native/media_device_info.dart
@@ -38,7 +38,7 @@ final _deviceId = dl
 
 final _free = dl.lookupFunction<_free_C, _free_Dart>('MediaDeviceInfo__free');
 
-class NativeMediaDeviceInfo extends MediaDeviceInfo {
+class NativeMediaDeviceInfo implements MediaDeviceInfo {
   /// [Pointer] to the Rust struct backing this object.
   late NullablePointer ptr;
 

--- a/flutter/lib/src/native/media_display_info.dart
+++ b/flutter/lib/src/native/media_display_info.dart
@@ -27,7 +27,7 @@ final _deviceId = dl
 
 final _free = dl.lookupFunction<_free_C, _free_Dart>('MediaDisplayInfo__free');
 
-class NativeMediaDisplayInfo extends MediaDisplayInfo {
+class NativeMediaDisplayInfo implements MediaDisplayInfo {
   /// [Pointer] to the Rust struct backing this object.
   late NullablePointer ptr;
 

--- a/flutter/lib/src/native/media_manager.dart
+++ b/flutter/lib/src/native/media_manager.dart
@@ -81,7 +81,7 @@ final _onDeviceChange =
 final _free =
     dl.lookupFunction<_free_C, _free_Dart>('MediaManagerHandle__free');
 
-class NativeMediaManagerHandle extends MediaManagerHandle {
+class NativeMediaManagerHandle implements MediaManagerHandle {
   /// [Pointer] to the Rust struct backing this object.
   late NullablePointer ptr;
 

--- a/flutter/lib/src/native/media_stream_settings.dart
+++ b/flutter/lib/src/native/media_stream_settings.dart
@@ -43,7 +43,7 @@ final _displayVideo = dl.lookupFunction<_displayVideo_C, _displayVideo_Dart>(
 final _free =
     dl.lookupFunction<_free_C, _free_Dart>('MediaStreamSettings__free');
 
-class MediaStreamSettings extends base.MediaStreamSettings {
+class MediaStreamSettings implements base.MediaStreamSettings {
   /// [Pointer] to the Rust struct backing this object.
   final NullablePointer ptr = NullablePointer(_new());
 

--- a/flutter/lib/src/native/reconnect_handle.dart
+++ b/flutter/lib/src/native/reconnect_handle.dart
@@ -28,7 +28,7 @@ final _reconnect_with_backoff =
     dl.lookupFunction<_reconnect_with_backoff_C, _reconnect_with_backoff_Dart>(
         'ReconnectHandle__reconnect_with_backoff');
 
-class NativeReconnectHandle extends ReconnectHandle {
+class NativeReconnectHandle implements ReconnectHandle {
   /// [Pointer] to the Rust struct backing this object.
   late NullablePointer ptr;
 

--- a/flutter/lib/src/native/remote_media_track.dart
+++ b/flutter/lib/src/native/remote_media_track.dart
@@ -125,12 +125,13 @@ class NativeRemoteMediaTrack extends RemoteMediaTrack {
 
   @moveSemantics
   @override
-  void free() {
+  Future<void> free() {
     if (!ptr.isFreed()) {
       RustHandlesStorage().removeHandle(this);
       _free(ptr.getInnerPtr());
       ptr.free();
     }
+    return Future.value();
   }
 
   @override

--- a/flutter/lib/src/native/remote_media_track.dart
+++ b/flutter/lib/src/native/remote_media_track.dart
@@ -70,7 +70,7 @@ final _getTrack = dl
 
 final _free = dl.lookupFunction<_free_C, _free_Dart>('RemoteMediaTrack__free');
 
-class NativeRemoteMediaTrack extends RemoteMediaTrack {
+class NativeRemoteMediaTrack implements RemoteMediaTrack {
   /// [Pointer] to the Rust struct that backing this object.
   late NullablePointer ptr;
 
@@ -125,13 +125,12 @@ class NativeRemoteMediaTrack extends RemoteMediaTrack {
 
   @moveSemantics
   @override
-  Future<void> free() {
+  Future<void> free() async {
     if (!ptr.isFreed()) {
       RustHandlesStorage().removeHandle(this);
       _free(ptr.getInnerPtr());
       ptr.free();
     }
-    return Future.value();
   }
 
   @override

--- a/flutter/lib/src/native/room_close_reason.dart
+++ b/flutter/lib/src/native/room_close_reason.dart
@@ -33,7 +33,7 @@ final _isErr =
 
 final _free = dl.lookupFunction<_free_C, _free_Dart>('RoomCloseReason__free');
 
-class NativeRoomCloseReason extends RoomCloseReason {
+class NativeRoomCloseReason implements RoomCloseReason {
   /// [Pointer] to the Rust struct that backing this object.
   late NullablePointer ptr;
 

--- a/flutter/lib/src/native/room_handle.dart
+++ b/flutter/lib/src/native/room_handle.dart
@@ -151,7 +151,7 @@ final _enableRemoteVideo =
     dl.lookupFunction<_enableRemoteVideo_C, _enableRemoteVideo_Dart>(
         'RoomHandle__enable_remote_video');
 
-class NativeRoomHandle extends RoomHandle {
+class NativeRoomHandle implements RoomHandle {
   /// [Pointer] to the Rust struct that backing this object.
   late NullablePointer ptr;
 

--- a/flutter/lib/src/util/rust_handles_storage.dart
+++ b/flutter/lib/src/util/rust_handles_storage.dart
@@ -5,14 +5,14 @@ import 'move_semantic.dart';
 /// Abstraction of a handle to an object allocated in the Rust side.
 abstract class PlatformHandle {}
 
-/// A [PlatformHandle] with an async destructor.
+/// [PlatformHandle] with an async destructor.
 abstract class AsyncPlatformHandle implements PlatformHandle {
   /// Drops the associated Rust struct and nulls the local [Pointer] to it.
   @moveSemantics
   Future<void> free();
 }
 
-/// A [PlatformHandle] with a sync destructor.
+/// [PlatformHandle] with a sync destructor.
 abstract class SyncPlatformHandle implements PlatformHandle {
   /// Drops the associated Rust struct and nulls the local [Pointer] to it.
   @moveSemantics

--- a/flutter/lib/src/util/rust_handles_storage.dart
+++ b/flutter/lib/src/util/rust_handles_storage.dart
@@ -6,14 +6,14 @@ import 'move_semantic.dart';
 abstract class _BasePlatformHandle {}
 
 /// Abstraction of a handle with async drop to an object allocated in the Rust side.
-abstract class AsyncPlatformHandle implements _BasePlatformHandle {
+abstract class AsyncPlatformHandle extends _BasePlatformHandle {
   /// Drops the associated Rust struct and nulls the local [Pointer] to it.
   @moveSemantics
   Future<void> free();
 }
 
 /// Abstraction of a handle with sync to an object allocated in the Rust side.
-abstract class SyncPlatformHandle implements _BasePlatformHandle {
+abstract class SyncPlatformHandle extends _BasePlatformHandle {
   /// Drops the associated Rust struct and nulls the local [Pointer] to it.
   @moveSemantics
   void free();
@@ -48,7 +48,7 @@ class RustHandlesStorage {
   }
 
   /// Disposes all the Rust handles registered in this [RustHandlesStorage].
-  void freeAll() async {
+  Future<void> freeAll() async {
     _isFreeingAll = true;
     for (var h in _handles.toList()) {
       if (h is AsyncPlatformHandle) {

--- a/flutter/lib/src/util/rust_handles_storage.dart
+++ b/flutter/lib/src/util/rust_handles_storage.dart
@@ -3,17 +3,17 @@ import 'dart:collection';
 import 'move_semantic.dart';
 
 /// Abstraction of a handle to an object allocated in the Rust side.
-abstract class _BasePlatformHandle {}
+abstract class PlatformHandle {}
 
-/// Abstraction of a handle with async drop to an object allocated in the Rust side.
-abstract class AsyncPlatformHandle extends _BasePlatformHandle {
+/// A [PlatformHandle] with an async destructor.
+abstract class AsyncPlatformHandle implements PlatformHandle {
   /// Drops the associated Rust struct and nulls the local [Pointer] to it.
   @moveSemantics
   Future<void> free();
 }
 
-/// Abstraction of a handle with sync to an object allocated in the Rust side.
-abstract class SyncPlatformHandle extends _BasePlatformHandle {
+/// A [PlatformHandle] with a sync destructor.
+abstract class SyncPlatformHandle implements PlatformHandle {
   /// Drops the associated Rust struct and nulls the local [Pointer] to it.
   @moveSemantics
   void free();
@@ -24,7 +24,7 @@ class RustHandlesStorage {
   static final RustHandlesStorage _singleton = RustHandlesStorage._internal();
 
   /// All handles given for the Dart side from the Rust side.
-  final HashSet<_BasePlatformHandle> _handles = HashSet();
+  final HashSet<PlatformHandle> _handles = HashSet();
 
   /// Indicator whether this [RustHandlesStorage] frees all the [_handles].
   bool _isFreeingAll = false;
@@ -36,12 +36,12 @@ class RustHandlesStorage {
   RustHandlesStorage._internal();
 
   /// Insert the provided [handle] to this [RustHandlesStorage].
-  void insertHandle(_BasePlatformHandle handle) {
+  void insertHandle(PlatformHandle handle) {
     _handles.add(handle);
   }
 
   /// Removes the provided [handle] from this [RustHandlesStorage].
-  void removeHandle(_BasePlatformHandle handle) {
+  void removeHandle(PlatformHandle handle) {
     if (!_isFreeingAll) {
       _handles.remove(handle);
     }

--- a/flutter/lib/src/web/audio_track_constraints.dart
+++ b/flutter/lib/src/web/audio_track_constraints.dart
@@ -3,7 +3,7 @@ import '../util/move_semantic.dart';
 import 'exceptions.dart';
 import 'jason_wasm.dart' as wasm;
 
-class AudioTrackConstraints extends base.AudioTrackConstraints {
+class AudioTrackConstraints implements base.AudioTrackConstraints {
   final wasm.AudioTrackConstraints obj = wasm.AudioTrackConstraints();
 
   @override

--- a/flutter/lib/src/web/connection_handle.dart
+++ b/flutter/lib/src/web/connection_handle.dart
@@ -9,7 +9,7 @@ import 'exceptions.dart';
 import 'jason_wasm.dart' as wasm;
 import 'remote_media_track.dart';
 
-class WebConnectionHandle extends ConnectionHandle {
+class WebConnectionHandle implements ConnectionHandle {
   late wasm.ConnectionHandle obj;
 
   WebConnectionHandle(this.obj);

--- a/flutter/lib/src/web/device_video_track_constraints.dart
+++ b/flutter/lib/src/web/device_video_track_constraints.dart
@@ -3,7 +3,7 @@ import '../util/move_semantic.dart';
 import 'exceptions.dart';
 import 'jason_wasm.dart' as wasm;
 
-class DeviceVideoTrackConstraints extends base.DeviceVideoTrackConstraints {
+class DeviceVideoTrackConstraints implements base.DeviceVideoTrackConstraints {
   final wasm.DeviceVideoTrackConstraints obj =
       wasm.DeviceVideoTrackConstraints();
 

--- a/flutter/lib/src/web/display_video_track_constraints.dart
+++ b/flutter/lib/src/web/display_video_track_constraints.dart
@@ -3,7 +3,8 @@ import '../util/move_semantic.dart';
 import 'exceptions.dart';
 import 'jason_wasm.dart' as wasm;
 
-class DisplayVideoTrackConstraints extends base.DisplayVideoTrackConstraints {
+class DisplayVideoTrackConstraints
+    implements base.DisplayVideoTrackConstraints {
   final wasm.DisplayVideoTrackConstraints obj =
       wasm.DisplayVideoTrackConstraints();
 

--- a/flutter/lib/src/web/exceptions.dart
+++ b/flutter/lib/src/web/exceptions.dart
@@ -70,7 +70,7 @@ Future<T> fallibleFuture<T>(Future<T> f) async {
 }
 
 /// Exception thrown when cannot get info of available media devices.
-class WebEnumerateDevicesException extends EnumerateDevicesException {
+class WebEnumerateDevicesException implements EnumerateDevicesException {
   late dynamic _cause;
   late String _trace;
 
@@ -97,7 +97,7 @@ class WebEnumerateDevicesException extends EnumerateDevicesException {
 ///
 /// This is either a programmatic error or some unexpected platform component
 /// failure that cannot be handled in any way.
-class WebInternalException extends InternalException {
+class WebInternalException implements InternalException {
   late String _message;
   late dynamic _cause;
   late String _trace;
@@ -129,7 +129,7 @@ class WebInternalException extends InternalException {
 }
 
 /// Exception thrown when accessing media devices.
-class WebLocalMediaInitException extends LocalMediaInitException {
+class WebLocalMediaInitException implements LocalMediaInitException {
   late LocalMediaInitExceptionKind _kind;
   late String _message;
   late dynamic _cause;
@@ -169,7 +169,7 @@ class WebLocalMediaInitException extends LocalMediaInitException {
 }
 
 /// Errors occurring in `RoomHandle::set_local_media_settings()` method.
-class WebMediaSettingsUpdateException extends MediaSettingsUpdateException {
+class WebMediaSettingsUpdateException implements MediaSettingsUpdateException {
   late String _message;
   late dynamic _cause;
   late bool _rolledBack;
@@ -203,7 +203,8 @@ class WebMediaSettingsUpdateException extends MediaSettingsUpdateException {
 
 /// Exception thrown when the requested media state transition could not be
 /// performed.
-class WebMediaStateTransitionException extends MediaStateTransitionException {
+class WebMediaStateTransitionException
+    implements MediaStateTransitionException {
   late String _message;
   late String _trace;
   late MediaStateTransitionExceptionKind _kind;
@@ -236,7 +237,7 @@ class WebMediaStateTransitionException extends MediaStateTransitionException {
 
 /// Exceptions thrown from an RPC client that implements messaging with a media
 /// server.
-class WebRpcClientException extends RpcClientException {
+class WebRpcClientException implements RpcClientException {
   late RpcClientExceptionKind _kind;
   late String _message;
   late dynamic _cause;

--- a/flutter/lib/src/web/local_media_track.dart
+++ b/flutter/lib/src/web/local_media_track.dart
@@ -29,7 +29,8 @@ class WebLocalMediaTrack extends LocalMediaTrack {
 
   @moveSemantics
   @override
-  void free() {
+  Future<void> free() {
     obj.free();
+    return Future.value();
   }
 }

--- a/flutter/lib/src/web/local_media_track.dart
+++ b/flutter/lib/src/web/local_media_track.dart
@@ -6,7 +6,7 @@ import '../util/move_semantic.dart';
 import 'exceptions.dart';
 import 'jason_wasm.dart' as wasm;
 
-class WebLocalMediaTrack extends LocalMediaTrack {
+class WebLocalMediaTrack implements LocalMediaTrack {
   late wasm.LocalMediaTrack obj;
 
   WebLocalMediaTrack(this.obj);
@@ -29,8 +29,7 @@ class WebLocalMediaTrack extends LocalMediaTrack {
 
   @moveSemantics
   @override
-  Future<void> free() {
+  Future<void> free() async {
     obj.free();
-    return Future.value();
   }
 }

--- a/flutter/lib/src/web/media_device_info.dart
+++ b/flutter/lib/src/web/media_device_info.dart
@@ -3,7 +3,7 @@ import '../util/move_semantic.dart';
 import 'exceptions.dart';
 import 'jason_wasm.dart' as wasm;
 
-class WebMediaDeviceInfo extends MediaDeviceInfo {
+class WebMediaDeviceInfo implements MediaDeviceInfo {
   late wasm.MediaDeviceInfo obj;
 
   WebMediaDeviceInfo(this.obj);

--- a/flutter/lib/src/web/media_manager.dart
+++ b/flutter/lib/src/web/media_manager.dart
@@ -15,7 +15,7 @@ import 'local_media_track.dart';
 import 'media_device_info.dart';
 import 'media_stream_settings.dart';
 
-class WebMediaManagerHandle extends MediaManagerHandle {
+class WebMediaManagerHandle implements MediaManagerHandle {
   late wasm.MediaManagerHandle obj;
 
   WebMediaManagerHandle(this.obj);

--- a/flutter/lib/src/web/media_stream_settings.dart
+++ b/flutter/lib/src/web/media_stream_settings.dart
@@ -11,7 +11,7 @@ import 'jason_wasm.dart' as wasm;
 import '../interface/display_video_track_constraints.dart'
     as base_display_video;
 
-class MediaStreamSettings extends base.MediaStreamSettings {
+class MediaStreamSettings implements base.MediaStreamSettings {
   final wasm.MediaStreamSettings obj = wasm.MediaStreamSettings();
 
   @override

--- a/flutter/lib/src/web/reconnect_handle.dart
+++ b/flutter/lib/src/web/reconnect_handle.dart
@@ -3,7 +3,7 @@ import '../util/move_semantic.dart';
 import 'exceptions.dart';
 import 'jason_wasm.dart' as wasm;
 
-class WebReconnectHandle extends ReconnectHandle {
+class WebReconnectHandle implements ReconnectHandle {
   late wasm.ReconnectHandle obj;
 
   WebReconnectHandle(this.obj);

--- a/flutter/lib/src/web/remote_media_track.dart
+++ b/flutter/lib/src/web/remote_media_track.dart
@@ -56,8 +56,9 @@ class WebRemoteMediaTrack extends RemoteMediaTrack {
 
   @moveSemantics
   @override
-  void free() {
+  Future<void> free() {
     obj.free();
+    return Future.value();
   }
 
   @override

--- a/flutter/lib/src/web/remote_media_track.dart
+++ b/flutter/lib/src/web/remote_media_track.dart
@@ -7,7 +7,7 @@ import '../util/move_semantic.dart';
 import 'exceptions.dart';
 import 'jason_wasm.dart' as wasm;
 
-class WebRemoteMediaTrack extends RemoteMediaTrack {
+class WebRemoteMediaTrack implements RemoteMediaTrack {
   late wasm.RemoteMediaTrack obj;
 
   WebRemoteMediaTrack(this.obj);
@@ -56,9 +56,8 @@ class WebRemoteMediaTrack extends RemoteMediaTrack {
 
   @moveSemantics
   @override
-  Future<void> free() {
+  Future<void> free() async {
     obj.free();
-    return Future.value();
   }
 
   @override

--- a/flutter/lib/src/web/room_close_reason.dart
+++ b/flutter/lib/src/web/room_close_reason.dart
@@ -3,7 +3,7 @@ import '../util/move_semantic.dart';
 import 'exceptions.dart';
 import 'jason_wasm.dart' as wasm;
 
-class WebRoomCloseReason extends RoomCloseReason {
+class WebRoomCloseReason implements RoomCloseReason {
   late wasm.RoomCloseReason obj;
 
   WebRoomCloseReason(this.obj);

--- a/flutter/lib/src/web/room_handle.dart
+++ b/flutter/lib/src/web/room_handle.dart
@@ -15,7 +15,7 @@ import 'media_stream_settings.dart';
 import 'reconnect_handle.dart';
 import 'room_close_reason.dart';
 
-class WebRoomHandle extends RoomHandle {
+class WebRoomHandle implements RoomHandle {
   late wasm.RoomHandle obj;
 
   WebRoomHandle(this.obj);

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   ffi: ^2.0.1
   http: ^0.13.5
   js: ^0.6.5
-  medea_flutter_webrtc: 0.8.0-dev+rev.0ef956e098dfe3ef20c108e6b60ca5f285310409
+  medea_flutter_webrtc: 0.8.0-dev+rev.39f8181e33a20db445d16c1bfedd7d337a777fe3
   retry: ^3.1.0
   tuple: ^2.0.1
   uuid: ^3.0.7

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   ffi: ^2.0.1
   http: ^0.13.5
   js: ^0.6.5
-  medea_flutter_webrtc: 0.8.0-dev+rev.39f8181e33a20db445d16c1bfedd7d337a777fe3
+  medea_flutter_webrtc: 0.8.0-dev+rev.0ef956e098dfe3ef20c108e6b60ca5f285310409
   retry: ^3.1.0
   tuple: ^2.0.1
   uuid: ^3.0.7

--- a/flutter/test/e2e/steps/media_state.dart
+++ b/flutter/test/e2e/steps/media_state.dart
@@ -2,8 +2,6 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gherkin/gherkin.dart';
-import 'package:medea_flutter_webrtc/medea_flutter_webrtc.dart' as fw;
-import 'package:retry/retry.dart';
 
 import 'package:medea_jason/medea_jason.dart';
 import '../world/custom_world.dart';

--- a/flutter/test/e2e/steps/media_state.dart
+++ b/flutter/test/e2e/steps/media_state.dart
@@ -135,13 +135,7 @@ StepDefinitionGeneric then_track_is_stopped =
     var track =
         await member.wait_local_track(parsedKind.item2, parsedKind.item1);
 
-    var track_ = track.getTrack();
-    track.free();
-
-    // We might have to wait for Rust side for a little bit.
-    await retry(() async {
-      expect(await track_.state(), fw.MediaStreamTrackState.ended);
-    });
+    await track.free();
   },
 );
 

--- a/flutter/test/e2e/world/member.dart
+++ b/flutter/test/e2e/world/member.dart
@@ -243,10 +243,9 @@ class Member {
 
   /// Frees all the [LocalMediaTrack]s of this [Member].
   Future<void> forget_local_tracks() async {
-    connection_store.local_tracks.forEach((track) {
-      track.free();
-    });
-    await Future.delayed(Duration(milliseconds: 100));
+    for (var track in connection_store.local_tracks) {
+      await track.free();
+    }
   }
 
   /// Waits for a [ConnectionHandle] from the [Member] with the provided [id].

--- a/src/api/dart/local_media_track.rs
+++ b/src/api/dart/local_media_track.rs
@@ -70,7 +70,7 @@ pub unsafe extern "C" fn LocalMediaTrack__free(
     propagate_panic(move || {
         let track = LocalMediaTrack::from_ptr(this);
         async move {
-            track.get_track().stop().await;
+            track.maybe_stop().await;
             Ok::<_, Error>(())
         }
         .into_dart_future()
@@ -112,6 +112,10 @@ mod mock {
         #[must_use]
         pub fn get_track(&self) -> platform::MediaStreamTrack {
             unreachable!()
+        }
+
+        pub async fn maybe_stop(self) {
+            // no-op
         }
     }
 }

--- a/src/api/dart/local_media_track.rs
+++ b/src/api/dart/local_media_track.rs
@@ -114,6 +114,7 @@ mod mock {
             unreachable!()
         }
 
+        #[allow(clippy::unused_async)]
         pub async fn maybe_stop(self) {
             // no-op
         }

--- a/src/api/dart/local_media_track.rs
+++ b/src/api/dart/local_media_track.rs
@@ -2,7 +2,10 @@ use std::ptr;
 
 use dart_sys::Dart_Handle;
 
-use super::{ForeignClass, utils::{DartFuture, IntoDartFuture}};
+use super::{
+    utils::{DartFuture, IntoDartFuture},
+    ForeignClass,
+};
 
 use crate::{
     api::{dart::propagate_panic, Error},
@@ -66,7 +69,11 @@ pub unsafe extern "C" fn LocalMediaTrack__free(
 ) -> DartFuture<Result<(), Error>> {
     propagate_panic(move || {
         let track = LocalMediaTrack::from_ptr(this);
-        async move {Ok::<_, Error>(track.get_track().stop().await)}.into_dart_future()
+        async move {
+            track.get_track().stop().await;
+            Ok::<_, Error>(())
+        }
+        .into_dart_future()
     })
 }
 

--- a/src/media/track/local.rs
+++ b/src/media/track/local.rs
@@ -109,6 +109,13 @@ impl Track {
             _parent: Some(parent),
         }
     }
+
+    /// [Stops][1] this [`Track`].
+    ///
+    /// [1]: https://w3.org/TR/mediacapture-streams#dom-mediastreamtrack-stop
+    pub async fn stop(&self) {
+        self.track.stop().await;
+    }
 }
 
 impl Drop for Track {
@@ -155,5 +162,15 @@ impl LocalMediaTrack {
     #[must_use]
     pub fn media_source_kind(&self) -> MediaSourceKind {
         self.0.media_source_kind().into()
+    }
+
+    /// [Stops][1] this [`LocalMediaTrack`] if this is the last wrapper for an
+    /// underlying [`Track`].
+    ///
+    /// [1]: https://w3.org/TR/mediacapture-streams#dom-mediastreamtrack-stop
+    pub async fn maybe_stop(mut self) {
+        if let Some(track) = Rc::get_mut(&mut self.0) {
+            track.stop().await;
+        }
     }
 }

--- a/src/media/track/local.rs
+++ b/src/media/track/local.rs
@@ -164,7 +164,7 @@ impl LocalMediaTrack {
         self.0.media_source_kind().into()
     }
 
-    /// [Stops][1] this [`LocalMediaTrack`] if this is the last wrapper for an
+    /// [Stops][1] this [`LocalMediaTrack`] if this is the last wrapper for the
     /// underlying [`Track`].
     ///
     /// [1]: https://w3.org/TR/mediacapture-streams#dom-mediastreamtrack-stop


### PR DESCRIPTION
Fixes #94

## Synopsis
`track.free()` is asynchronous which was causing the race

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed
  
[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
[1]: https://developer.android.com/reference/android/media/AudioManager#addOnCommunicationDeviceChangedListener(java.util.concurrent.Executor,%20android.media.AudioManager.OnCommunicationDeviceChangedListener)