### PR TITLE
Fix `TrackPatchEvent::merge`

### DIFF
--- a/proto/client-api/src/lib.rs
+++ b/proto/client-api/src/lib.rs
@@ -825,6 +825,10 @@ impl TrackPatchEvent {
         if let Some(direction) = another.media_direction {
             self.media_direction = Some(direction);
         }
+
+        if let Some(receivers) = &another.receivers {
+            self.receivers = Some(receivers.clone());
+        }
     }
 }
 


### PR DESCRIPTION
## Synopsis

Make `TrackPatchEvent::merge` method to merge also `receivers`. 




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [ ] and approved
- [ ] [Review][l:2] is completed and changes are approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] `Draft: ` prefix is removed
    - [ ] All temporary labels are removed
  
[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests