### PR TITLE
Fix error handling after wasm-pack update

### DIFF
--- a/e2e/src/browser/client.rs
+++ b/e2e/src/browser/client.rs
@@ -246,7 +246,7 @@ impl Inner {
                         {inner_js}
                         callback({{ ok: lastResult }});
                     }} catch (e) {{
-                        if (e.ptr != undefined) {{
+                        if (e.__wbg_ptr > 0) {{
                             callback({{
                                 err: {{
                                     kind: e.kind ? e.kind() : undefined,
@@ -256,7 +256,7 @@ impl Inner {
                                 }}
                             }});
                         }} else {{
-                            callback({{ err: e.toString() }});
+                            callback({{ err: JSON.stringify(e) }});
                         }}
                     }}
                 }}


### PR DESCRIPTION
Error handling in medea-e2e relying on fact the wasm-pack objects are marked with `ptr` field, but it was renamed to `__wbg_ptr` in https://github.com/rustwasm/wasm-bindgen/pull/3408