### PR TITLE
Prepare medea-control-api-proto 0.9.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "medea-control-api-proto"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "derive_more",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,7 +1684,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.2",
- "rustix 0.38.3",
+ "rustix 0.38.4",
  "windows-sys 0.48.0",
 ]
 
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "medea-control-api-proto"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2566,9 +2566,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.3"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac5ffa1efe7548069688cd7028f32591853cd7b5b756d41bcffd2353e4fc75b4"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
@@ -2749,9 +2749,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
+checksum = "b5062a995d481b2308b6064e9af76011f2921c35f97b0468811ed9f6cd91dfed"
 dependencies = [
  "itoa",
  "ryu",

--- a/mock/control-api/Cargo.toml
+++ b/mock/control-api/Cargo.toml
@@ -20,7 +20,7 @@ clap = { version = "4.0", features = ["derive", "wrap_help"] }
 derive_more = "0.99"
 dotenv = "0.15"
 humantime-serde = "1.0"
-medea-control-api-proto = { version = "0.8.0-dev", path = "../../proto/control-api", features = ["grpc", "client"] }
+medea-control-api-proto = { version = "0.8.1", path = "../../proto/control-api", features = ["grpc", "client"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 slog = "2.5"

--- a/mock/control-api/Cargo.toml
+++ b/mock/control-api/Cargo.toml
@@ -20,7 +20,7 @@ clap = { version = "4.0", features = ["derive", "wrap_help"] }
 derive_more = "0.99"
 dotenv = "0.15"
 humantime-serde = "1.0"
-medea-control-api-proto = { version = "0.8.1", path = "../../proto/control-api", features = ["grpc", "client"] }
+medea-control-api-proto = { version = "0.9", path = "../../proto/control-api", features = ["grpc", "client"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 slog = "2.5"

--- a/proto/control-api/CHANGELOG.md
+++ b/proto/control-api/CHANGELOG.md
@@ -6,15 +6,15 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
-## [0.8.1] · 2023-07-12
-[0.8.1]: /../../tree/medea-control-api-proto-0.8.1/proto/control-api
+## [0.9.0] · 2023-07-12
+[0.9.0]: /../../tree/medea-control-api-proto-0.9.0/proto/control-api
 
-[Diff](/../../compare/medea-control-api-proto-0.8.0...medea-control-api-proto-0.8.1)
+[Diff](/../../compare/medea-control-api-proto-0.8.0...medea-control-api-proto-0.9.0)
 
 ### Upgraded
 
 - Dependencies:
-    - [`medea-client-api-proto`] to `0.5` ([123]).
+    - [`medea-client-api-proto`] to `0.5` ([#123]).
 
 [#123]: /../../pull/123
 
@@ -193,9 +193,8 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
-
+[`medea-client-api-proto`]: https://docs.rs/medea-client-api-proto
 [`prost`]: https://docs.rs/prost
 [`tonic`]: https://docs.rs/tonic
-[`medea-client-api-proto`]: https://docs.rs/medea_client_api_proto
 
 [Semantic Versioning 2.0.0]: https://semver.org

--- a/proto/control-api/CHANGELOG.md
+++ b/proto/control-api/CHANGELOG.md
@@ -6,6 +6,21 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.8.1] · 2023-07-12
+[0.8.1]: /../../tree/medea-control-api-proto-0.8.1/proto/control-api
+
+[Diff](/../../compare/medea-control-api-proto-0.8.0...medea-control-api-proto-0.8.1)
+
+### Upgraded
+
+- Dependencies:
+    - [`medea-client-api-proto`] to `0.5` ([123]).
+
+[#123]: /../../pull/123
+
+
+
+
 ## [0.8.0] · 2023-06-09
 [0.8.0]: /../../tree/medea-control-api-proto-0.8.0/proto/control-api
 
@@ -181,5 +196,6 @@ All user visible changes to this project will be documented in this file. This p
 
 [`prost`]: https://docs.rs/prost
 [`tonic`]: https://docs.rs/tonic
+[`medea-client-api-proto`]: https://docs.rs/medea_client_api_proto
 
 [Semantic Versioning 2.0.0]: https://semver.org

--- a/proto/control-api/Cargo.toml
+++ b/proto/control-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "medea-control-api-proto"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.62"
 description = "Control API protocol implementation for Medea media server."

--- a/proto/control-api/Cargo.toml
+++ b/proto/control-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "medea-control-api-proto"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.62"
 description = "Control API protocol implementation for Medea media server."

--- a/proto/control-api/src/grpc/api.rs
+++ b/proto/control-api/src/grpc/api.rs
@@ -670,3 +670,383 @@ pub mod control_api_client {
         }
     }
 }
+/// Generated server implementations.
+pub mod control_api_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with ControlApiServer.
+    #[async_trait]
+    pub trait ControlApi: Send + Sync + 'static {
+        /// Creates a new `Element` on the media server.
+        ///
+        /// Non-idempotent. Errors if an `Element` with such ID already exists.
+        async fn create(
+            &self,
+            request: tonic::Request<super::CreateRequest>,
+        ) -> std::result::Result<tonic::Response<super::CreateResponse>, tonic::Status>;
+        /// Removes `Element`s from the media server.
+        /// Allows referring multiple `Element`s on the last two levels of a FID.
+        ///
+        /// Idempotent. If no `Element`s with such FIDs exist, then succeeds.
+        async fn delete(
+            &self,
+            request: tonic::Request<super::IdRequest>,
+        ) -> std::result::Result<tonic::Response<super::Response>, tonic::Status>;
+        /// Lookups `Element`s by their FIDs on the media server.
+        /// If no FIDs are specified, then returns all the current `Element`s on the
+        /// media server.
+        async fn get(
+            &self,
+            request: tonic::Request<super::IdRequest>,
+        ) -> std::result::Result<tonic::Response<super::GetResponse>, tonic::Status>;
+        /// Applies changes to an existing `Element` on the media server, or creates a
+        /// new one in case there is no `Element` with such ID.
+        ///
+        /// Idempotent. If no `Element` with such ID exists, then it will be created,
+        /// otherwise it will be reconfigured. `Element`s that exist on the same
+        /// hierarchy level, but are not specified in the provided spec, will be
+        /// removed.
+        async fn apply(
+            &self,
+            request: tonic::Request<super::ApplyRequest>,
+        ) -> std::result::Result<tonic::Response<super::CreateResponse>, tonic::Status>;
+        /// Checks healthiness of the media server.
+        /// Caller should assert that the returned `Pong` has the same nonce as the
+        /// sent `Ping`.
+        async fn healthz(
+            &self,
+            request: tonic::Request<super::Ping>,
+        ) -> std::result::Result<tonic::Response<super::Pong>, tonic::Status>;
+    }
+    /// Service allowing to control a media server dynamically, by creating, updating
+    /// and destroying pipelines of media `Element`s on it.
+    #[derive(Debug)]
+    pub struct ControlApiServer<T: ControlApi> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: ControlApi> ControlApiServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for ControlApiServer<T>
+    where
+        T: ControlApi,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/api.ControlApi/Create" => {
+                    #[allow(non_camel_case_types)]
+                    struct CreateSvc<T: ControlApi>(pub Arc<T>);
+                    impl<T: ControlApi> tonic::server::UnaryService<super::CreateRequest>
+                    for CreateSvc<T> {
+                        type Response = super::CreateResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::CreateRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).create(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = CreateSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/api.ControlApi/Delete" => {
+                    #[allow(non_camel_case_types)]
+                    struct DeleteSvc<T: ControlApi>(pub Arc<T>);
+                    impl<T: ControlApi> tonic::server::UnaryService<super::IdRequest>
+                    for DeleteSvc<T> {
+                        type Response = super::Response;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::IdRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).delete(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = DeleteSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/api.ControlApi/Get" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetSvc<T: ControlApi>(pub Arc<T>);
+                    impl<T: ControlApi> tonic::server::UnaryService<super::IdRequest>
+                    for GetSvc<T> {
+                        type Response = super::GetResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::IdRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).get(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = GetSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/api.ControlApi/Apply" => {
+                    #[allow(non_camel_case_types)]
+                    struct ApplySvc<T: ControlApi>(pub Arc<T>);
+                    impl<T: ControlApi> tonic::server::UnaryService<super::ApplyRequest>
+                    for ApplySvc<T> {
+                        type Response = super::CreateResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ApplyRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).apply(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = ApplySvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/api.ControlApi/Healthz" => {
+                    #[allow(non_camel_case_types)]
+                    struct HealthzSvc<T: ControlApi>(pub Arc<T>);
+                    impl<T: ControlApi> tonic::server::UnaryService<super::Ping>
+                    for HealthzSvc<T> {
+                        type Response = super::Pong;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::Ping>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).healthz(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = HealthzSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
+            }
+        }
+    }
+    impl<T: ControlApi> Clone for ControlApiServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    impl<T: ControlApi> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(Arc::clone(&self.0))
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: ControlApi> tonic::server::NamedService for ControlApiServer<T> {
+        const NAME: &'static str = "api.ControlApi";
+    }
+}

--- a/proto/control-api/src/grpc/callback.rs
+++ b/proto/control-api/src/grpc/callback.rs
@@ -93,6 +93,116 @@ pub mod on_leave {
         }
     }
 }
+/// Generated client implementations.
+pub mod callback_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    /// Service for receiving callbacks from a media server.
+    #[derive(Debug, Clone)]
+    pub struct CallbackClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl CallbackClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> CallbackClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> CallbackClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            CallbackClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        /// Fires when a certain callback event happens on a media server.
+        pub async fn on_event(
+            &mut self,
+            request: impl tonic::IntoRequest<super::Request>,
+        ) -> std::result::Result<tonic::Response<super::Response>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/callback.Callback/OnEvent",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new("callback.Callback", "OnEvent"));
+            self.inner.unary(req, path, codec).await
+        }
+    }
+}
 /// Generated server implementations.
 pub mod callback_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]


### PR DESCRIPTION
Prepares `medea-control-api-proto` 0.9.0 release.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entries][l:3] are verified and corrected
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests