### PR TITLE
Fix firefox screenshare

### DIFF
--- a/src/media/constraints.rs
+++ b/src/media/constraints.rs
@@ -997,10 +997,7 @@ impl AudioTrackConstraints {
     ) -> bool {
         let track = track.as_ref();
         satisfies_track(track, MediaKind::Audio).await
-            && ConstrainString::satisfies(
-                &self.device_id,
-                &Some(track.device_id()),
-            )
+            && ConstrainString::satisfies(&self.device_id, &track.device_id())
         // TODO returns Result<bool, Error>
     }
 
@@ -1213,10 +1210,7 @@ impl DeviceVideoTrackConstraints {
     ) -> bool {
         let track = track.as_ref();
         satisfies_track(track, MediaKind::Video).await
-            && ConstrainString::satisfies(
-                &self.device_id,
-                &Some(track.device_id()),
-            )
+            && ConstrainString::satisfies(&self.device_id, &track.device_id())
             && ConstrainString::satisfies(
                 &self.facing_mode,
                 &track.facing_mode(),
@@ -1301,10 +1295,7 @@ impl DisplayVideoTrackConstraints {
     ) -> bool {
         let track = track.as_ref();
         satisfies_track(track, MediaKind::Video).await
-            && ConstrainString::satisfies(
-                &self.device_id,
-                &Some(track.device_id()),
-            )
+            && ConstrainString::satisfies(&self.device_id, &track.device_id())
             && ConstrainU32::satisfies(self.height, track.height())
             && ConstrainU32::satisfies(self.width, track.width())
             && track.guess_is_from_display()

--- a/src/platform/dart/media_track.rs
+++ b/src/platform/dart/media_track.rs
@@ -163,10 +163,10 @@ impl MediaStreamTrack {
     /// [1]: https://w3.org/TR/mediacapture-streams#dfn-deviceid
     #[inline]
     #[must_use]
-    pub fn device_id(&self) -> String {
+    pub fn device_id(&self) -> Option<String> {
         let device_id =
             unsafe { media_stream_track::device_id(self.inner.get()) };
-        unsafe { dart_string_into_rust(device_id) }
+        Some(unsafe { dart_string_into_rust(device_id) })
     }
 
     /// Returns [kind][1] of this [`MediaStreamTrack`].

--- a/src/platform/wasm/media_track.rs
+++ b/src/platform/wasm/media_track.rs
@@ -116,12 +116,11 @@ impl MediaStreamTrack {
     /// [1]: https://tinyurl.com/w3-streams#dom-mediatracksettings-deviceid
     /// [2]: https://w3.org/TR/mediacapture-streams#mediastreamtrack
     #[must_use]
-    pub fn device_id(&self) -> String {
+    pub fn device_id(&self) -> Option<String> {
         #[allow(clippy::unwrap_used)]
         get_property_by_name(&self.sys_track.get_settings(), "deviceId", |v| {
             v.as_string()
         })
-        .unwrap()
     }
 
     /// Return a [`facingMode`][1] of the underlying [MediaStreamTrack][2].


### PR DESCRIPTION
## Synopsis

Firefox `track.device_id` return `None` for screen share.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [ ] Documentation is updated (if required)
- [ ] Tests are updated (if required)
- [ ] Changes conform code style
- [ ] CHANGELOG entry is added (if required)
- [ ] FCM (final commit message) is posted
    - [ ] and approved
- [ ] [Review][l:2] is completed and changes are approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] `Draft: ` prefix is removed
    - [ ] All temporary labels are removed
  
[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests