### PR TITLE
Fix `SFU` blink direction test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,9 +341,6 @@ jobs:
         if: ${{ contains('ios macos', matrix.platform) }}
 
       - uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '3.16.4'
-          channel: 'stable'
       - name: Install Flutter Linux dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
 
 env:
   CACHE: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
-  MEDEA_BRANCH: edge
+  MEDEA_BRANCH: fix-blink-direction
   PROTOC_VER: 23.x
   RUST_BACKTRACE: 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,6 +341,9 @@ jobs:
         if: ${{ contains('ios macos', matrix.platform) }}
 
       - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.16.4'
+          channel: 'stable'
       - name: Install Flutter Linux dependencies
         run: |
           sudo apt-get update

--- a/e2e/tests/features/enable_remote_media.feature
+++ b/e2e/tests/features/enable_remote_media.feature
@@ -28,7 +28,7 @@ Feature: Enable remote media
     And joined member Bob
     When Bob disables video and awaits it completes
     And Bob enables video and awaits it completes
-    Then `on_enabled` callback fires 1 times on Alice's remote device video track from Bob
+    Then `on_enabled` callback fires 1 time on Alice's remote device video track from Bob
 
   @mesh
   Scenario: Remote member enables audio
@@ -37,4 +37,3 @@ Feature: Enable remote media
     When Bob disables audio and awaits it completes
     And Bob enables audio and awaits it completes
     Then `on_enabled` callback fires 1 time on Alice's remote audio track from Bob
-

--- a/e2e/tests/features/enable_remote_media.feature
+++ b/e2e/tests/features/enable_remote_media.feature
@@ -22,6 +22,7 @@ Feature: Enable remote media
     And `on_enabled` callback fires 0 times on Alice's remote device video track from Bob
     And `on_enabled` callback fires 0 times on Bob's remote device video track from Alice
 
+  @mesh
   Scenario: Remote member enables video
     Given room with joined member Alice
     And joined member Bob
@@ -29,7 +30,7 @@ Feature: Enable remote media
     And Bob enables video and awaits it completes
     Then `on_enabled` callback fires 1 times on Alice's remote device video track from Bob
 
-
+  @mesh
   Scenario: Remote member enables audio
     Given room with joined member Alice
     And joined member Bob

--- a/e2e/tests/features/enable_remote_media.feature
+++ b/e2e/tests/features/enable_remote_media.feature
@@ -12,28 +12,55 @@ Feature: Enable remote media
     When Alice enables remote audio
     Then `on_enabled` callback fires 1 time on Alice's remote audio track from Bob
 
-  @mesh
-  Scenario: `RemoteMediaTrack.on_enabled()` doesn't fire when track is created
+  Scenario Outline: `RemoteMediaTrack.on_enabled()` doesn't fire when track is created
     Given room with joined member Alice
     And member Bob
     When Bob joins the room
-    Then `on_enabled` callback fires 0 times on Alice's remote audio track from Bob
+    Then `on_enabled` callback fires <count> times on Alice's remote audio track from Bob
+    And `on_enabled` callback fires <count> times on Alice's remote device video track from Bob
     And `on_enabled` callback fires 0 times on Bob's remote audio track from Alice
-    And `on_enabled` callback fires 0 times on Alice's remote device video track from Bob
     And `on_enabled` callback fires 0 times on Bob's remote device video track from Alice
 
-  @mesh
-  Scenario: Remote member enables video
+    @mesh
+    Examples:
+      | count |
+      | 0     |
+
+    @sfu
+    Examples:
+      | count |
+      | 1     |
+
+  Scenario Outline: Remote member enables video
     Given room with joined member Alice
     And joined member Bob
     When Bob disables video and awaits it completes
     And Bob enables video and awaits it completes
-    Then `on_enabled` callback fires 1 time on Alice's remote device video track from Bob
+    Then `on_enabled` callback fires <count> times on Alice's remote device video track from Bob
 
-  @mesh
-  Scenario: Remote member enables audio
+    @mesh
+    Examples:
+      | count |
+      | 1     |
+
+    @sfu
+    Examples:
+      | count |
+      | 2     |
+
+  Scenario Outline: Remote member enables audio
     Given room with joined member Alice
     And joined member Bob
     When Bob disables audio and awaits it completes
     And Bob enables audio and awaits it completes
-    Then `on_enabled` callback fires 1 time on Alice's remote audio track from Bob
+    Then `on_enabled` callback fires <count> times on Alice's remote audio track from Bob
+
+    @mesh
+    Examples:
+      | count |
+      | 1     |
+
+    @sfu
+    Examples:
+      | count |
+      | 2     |

--- a/e2e/tests/features/enable_remote_media.feature
+++ b/e2e/tests/features/enable_remote_media.feature
@@ -22,36 +22,18 @@ Feature: Enable remote media
     And `on_enabled` callback fires 0 times on Alice's remote device video track from Bob
     And `on_enabled` callback fires 0 times on Bob's remote device video track from Alice
 
-  Scenario Outline: Remote member enables video
+  Scenario: Remote member enables video
     Given room with joined member Alice
     And joined member Bob
     When Bob disables video and awaits it completes
     And Bob enables video and awaits it completes
-    Then `on_enabled` callback fires <times> time on Alice's remote device video track from Bob
+    Then `on_enabled` callback fires 1 times on Alice's remote device video track from Bob
 
-    @mesh
-    Examples:
-      | times |
-      | 1     |
 
-    @sfu
-    Examples:
-      | times |
-      | 2     |
-
-  Scenario Outline: Remote member enables audio
+  Scenario: Remote member enables audio
     Given room with joined member Alice
     And joined member Bob
     When Bob disables audio and awaits it completes
     And Bob enables audio and awaits it completes
-    Then `on_enabled` callback fires <times> time on Alice's remote audio track from Bob
+    Then `on_enabled` callback fires 1 time on Alice's remote audio track from Bob
 
-    @mesh
-    Examples:
-      | times |
-      | 1     |
-
-    @sfu
-    Examples:
-      | times |
-      | 2     |

--- a/e2e/tests/features/enable_remote_media.feature
+++ b/e2e/tests/features/enable_remote_media.feature
@@ -12,6 +12,7 @@ Feature: Enable remote media
     When Alice enables remote audio
     Then `on_enabled` callback fires 1 time on Alice's remote audio track from Bob
 
+  @mesh
   Scenario: `RemoteMediaTrack.on_enabled()` doesn't fire when track is created
     Given room with joined member Alice
     And member Bob
@@ -21,16 +22,36 @@ Feature: Enable remote media
     And `on_enabled` callback fires 0 times on Alice's remote device video track from Bob
     And `on_enabled` callback fires 0 times on Bob's remote device video track from Alice
 
-  Scenario: Remote member enables video
+  Scenario Outline: Remote member enables video
     Given room with joined member Alice
     And joined member Bob
     When Bob disables video and awaits it completes
     And Bob enables video and awaits it completes
-    Then `on_enabled` callback fires 1 time on Alice's remote device video track from Bob
+    Then `on_enabled` callback fires <times> time on Alice's remote device video track from Bob
 
-  Scenario: Remote member enables audio
+    @mesh
+    Examples:
+      | times |
+      | 1     |
+
+    @sfu
+    Examples:
+      | times |
+      | 2     |
+
+  Scenario Outline: Remote member enables audio
     Given room with joined member Alice
     And joined member Bob
     When Bob disables audio and awaits it completes
     And Bob enables audio and awaits it completes
-    Then `on_enabled` callback fires 1 time on Alice's remote audio track from Bob
+    Then `on_enabled` callback fires <times> time on Alice's remote audio track from Bob
+
+    @mesh
+    Examples:
+      | times |
+      | 1     |
+
+    @sfu
+    Examples:
+      | times |
+      | 2     |

--- a/e2e/tests/features/get_user_media.feature
+++ b/e2e/tests/features/get_user_media.feature
@@ -1,7 +1,7 @@
 Feature: `getUserMedia()` requests
 
   Scenario: Member joins Room and its `getUserMedia()` errors
-    Given room with member Alice
+    Given room with member Alice with disabled audio publishing
     And Alice's `getUserMedia()` errors
     And joined member Bob
     When Alice joins the room

--- a/e2e/tests/world/mod.rs
+++ b/e2e/tests/world/mod.rs
@@ -16,7 +16,7 @@ use medea_e2e::{
     browser::{self, WebDriverClientBuilder, WindowFactory},
     object::{self, Jason, MediaKind, MediaSourceKind, Object},
 };
-use tokio::time::interval;
+use tokio::time::{interval, sleep};
 use uuid::Uuid;
 
 use crate::{conf, control};
@@ -381,6 +381,7 @@ impl World {
                         .wait_for_disabled()
                         .await?;
                 }
+                sleep(Duration::from_millis(1000)).await;
             }
         }
         Ok(())

--- a/flutter/lib/src/native/ffi/jason_api.g.freezed.dart
+++ b/flutter/lib/src/native/ffi/jason_api.g.freezed.dart
@@ -146,7 +146,7 @@ class _$ApiConstrainFacingMode_ExactImpl
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ApiConstrainFacingMode_ExactImpl &&
@@ -291,7 +291,7 @@ class _$ApiConstrainFacingMode_IdealImpl
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ApiConstrainFacingMode_IdealImpl &&
@@ -518,7 +518,7 @@ class _$ConstrainU32_ExactImpl implements ConstrainU32_Exact {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ConstrainU32_ExactImpl &&
@@ -662,7 +662,7 @@ class _$ConstrainU32_IdealImpl implements ConstrainU32_Ideal {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ConstrainU32_IdealImpl &&
@@ -813,7 +813,7 @@ class _$ConstrainU32_RangeImpl implements ConstrainU32_Range {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ConstrainU32_RangeImpl &&

--- a/flutter/test/e2e/steps/track.dart
+++ b/flutter/test/e2e/steps/track.dart
@@ -157,8 +157,6 @@ StepDefinitionGeneric thenCallbackFiresOnRemoteTrack =
     var member = context.world.members[id]!;
     await member.waitForConnect(remoteId);
 
-    await member.waitForConnect(remoteId);
-
     var parsedKind = parseMediaKind(kind);
     var track = await member.waitRemoteTrackFrom(
         remoteId, parsedKind.item2, parsedKind.item1);

--- a/flutter/test/e2e/world/custom_world.dart
+++ b/flutter/test/e2e/world/custom_world.dart
@@ -294,7 +294,7 @@ class CustomWorld extends FlutterWidgetTesterWorld {
         }
       }
 
-      await Future.delayed(const Duration(milliseconds: 500));
+      await Future.delayed(const Duration(milliseconds: 1000));
     }
   }
 

--- a/flutter/test/e2e/world/member.dart
+++ b/flutter/test/e2e/world/member.dart
@@ -211,18 +211,31 @@ class Member {
         });
 
         remoteTrack.onMediaDirectionChanged((direction) {
-          if (direction == TrackMediaDirection.sendRecv) {
-            connectionStore.callbackCounter[remoteTrackId]!
-                .update('enabled', (value) => value += 1);
-            connectionStore.onCallbackCounter[remoteTrackId]!['enabled']!(
-                connectionStore.callbackCounter[remoteTrackId]!['enabled']!);
-          } else {
+          if (direction != TrackMediaDirection.sendRecv) {
             connectionStore.callbackCounter[remoteTrackId]!
                 .update('disabled', (value) => value += 1);
 
             connectionStore.onCallbackCounter[remoteTrackId]!['disabled']!(
                 connectionStore.callbackCounter[remoteTrackId]!['disabled']!);
+          } else {
+            connectionStore.callbackCounter[remoteTrackId]!
+                .update('enabled', (value) => value += 1);
+            connectionStore.onCallbackCounter[remoteTrackId]!['enabled']!(
+                connectionStore.callbackCounter[remoteTrackId]!['enabled']!);
           }
+        // remoteTrack.onMediaDirectionChanged((direction) {
+        //   if (direction == TrackMediaDirection.sendRecv) {
+        //     connectionStore.callbackCounter[remoteTrackId]!
+        //         .update('enabled', (value) => value += 1);
+        //     connectionStore.onCallbackCounter[remoteTrackId]!['enabled']!(
+        //         connectionStore.callbackCounter[remoteTrackId]!['enabled']!);
+        //   } else {
+        //     connectionStore.callbackCounter[remoteTrackId]!
+        //         .update('disabled', (value) => value += 1);
+        //
+        //     connectionStore.onCallbackCounter[remoteTrackId]!['disabled']!(
+        //         connectionStore.callbackCounter[remoteTrackId]!['disabled']!);
+        //   }
           var keys = connectionStore.onMediaDirectionChanged.keys;
           for (var i = 0;
               i < connectionStore.onMediaDirectionChanged.length;

--- a/flutter/test/e2e/world/member.dart
+++ b/flutter/test/e2e/world/member.dart
@@ -223,19 +223,6 @@ class Member {
             connectionStore.onCallbackCounter[remoteTrackId]!['enabled']!(
                 connectionStore.callbackCounter[remoteTrackId]!['enabled']!);
           }
-        // remoteTrack.onMediaDirectionChanged((direction) {
-        //   if (direction == TrackMediaDirection.sendRecv) {
-        //     connectionStore.callbackCounter[remoteTrackId]!
-        //         .update('enabled', (value) => value += 1);
-        //     connectionStore.onCallbackCounter[remoteTrackId]!['enabled']!(
-        //         connectionStore.callbackCounter[remoteTrackId]!['enabled']!);
-        //   } else {
-        //     connectionStore.callbackCounter[remoteTrackId]!
-        //         .update('disabled', (value) => value += 1);
-        //
-        //     connectionStore.onCallbackCounter[remoteTrackId]!['disabled']!(
-        //         connectionStore.callbackCounter[remoteTrackId]!['disabled']!);
-        //   }
           var keys = connectionStore.onMediaDirectionChanged.keys;
           for (var i = 0;
               i < connectionStore.onMediaDirectionChanged.length;

--- a/flutter/test/e2e/world/member.dart
+++ b/flutter/test/e2e/world/member.dart
@@ -211,17 +211,17 @@ class Member {
         });
 
         remoteTrack.onMediaDirectionChanged((direction) {
-          if (direction != TrackMediaDirection.sendRecv) {
+          if (direction == TrackMediaDirection.sendRecv) {
+            connectionStore.callbackCounter[remoteTrackId]!
+                .update('enabled', (value) => value += 1);
+            connectionStore.onCallbackCounter[remoteTrackId]!['enabled']!(
+                connectionStore.callbackCounter[remoteTrackId]!['enabled']!);
+          } else {
             connectionStore.callbackCounter[remoteTrackId]!
                 .update('disabled', (value) => value += 1);
 
             connectionStore.onCallbackCounter[remoteTrackId]!['disabled']!(
                 connectionStore.callbackCounter[remoteTrackId]!['disabled']!);
-          } else {
-            connectionStore.callbackCounter[remoteTrackId]!
-                .update('enabled', (value) => value += 1);
-            connectionStore.onCallbackCounter[remoteTrackId]!['enabled']!(
-                connectionStore.callbackCounter[remoteTrackId]!['enabled']!);
           }
           var keys = connectionStore.onMediaDirectionChanged.keys;
           for (var i = 0;


### PR DESCRIPTION
## Synopsis

Fail SFU `on_enabled` cb  tests.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed
  
[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests