### PR TITLE
Fix flaky E2E tests

### DIFF
--- a/e2e/tests/features/media_disable.feature
+++ b/e2e/tests/features/media_disable.feature
@@ -30,14 +30,20 @@ Feature: Media enabling/disabling
     Given room with joined member Alice
     And member Bob with disabled audio publishing
     When Bob joins the room
-    And Bob enables audio and awaits it completes
+    Then Alice receives connection with Bob
+    And Bob receives connection with Alice
+    And Alice doesn't have live audio remote track from Bob
+    When Bob enables audio and awaits it completes
     Then Alice's audio remote track from Bob is enabled
 
   Scenario: Member enables video during call
     Given room with joined member Alice
     And member Bob with disabled video publishing
     When Bob joins the room
-    And Bob enables video and awaits it completes
+    Then Alice receives connection with Bob
+    And Bob receives connection with Alice
+    And Alice doesn't have live device video remote track from Bob
+    When Bob enables video and awaits it completes
     Then Alice's device video remote track from Bob is enabled
 
   Scenario: Local track is dropped when video is disabled


### PR DESCRIPTION
## Synopsis

These e2e tests are really flaky:

```
Feature: Media enabling/disabling
  Scenario: Member enables audio during call
    Given room with joined member Alice
    And member Bob with disabled audio publishing
    When Bob joins the room
    And Bob enables audio and awaits it completes
    Then Alice's audio remote track from Bob is enabled

  Scenario: Member enables video during call
    Given room with joined member Alice
    And member Bob with disabled video publishing
    When Bob joins the room
    And Bob enables video and awaits it completes
    Then Alice's device video remote track from Bob is enabled
```

So I've debugged them a little bit and whats going on is that `Bob enables *` part (which is a `RoomHandle.enable_*` call) happens *during* the initial negotiation, between `PeerCreated { role: Answererer(sdp) }` and `MakeSdpAnswer { sdp_answer }` events. 

## Solution

So now we have two problems, first is that test is not doing what it is supposed to, and that server-side seems to break if both disable and enable track request are emitted by client during negotiation.

This PR resolves the first problem by waiting till `on_new_connection` is fired on both members before enabling the track. 

Second problem should be resolved in medea.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
