### PR TITLE
Filter empty ICE candidates on desktop platforms

### DIFF
--- a/src/platform/dart/peer_connection.rs
+++ b/src/platform/dart/peer_connection.rs
@@ -227,8 +227,8 @@ impl RtcPeerConnection {
                     Callback::from_fn_mut(move |handle: DartHandle| {
                         let candidate = PlatformIceCandidate::from(handle);
                         // Empty `candidate.candidate()` means that all ICE
-                        // transports have
-                        // finished gathering candidates.
+                        // transports have finished gathering candidates.
+                        //
                         // Doesn't need to be delivered onward to the remote
                         // peer.
                         if !candidate.candidate().is_empty() {

--- a/src/platform/dart/peer_connection.rs
+++ b/src/platform/dart/peer_connection.rs
@@ -226,7 +226,7 @@ impl RtcPeerConnection {
                     self.handle.get(),
                     Callback::from_fn_mut(move |handle: DartHandle| {
                         let candidate = PlatformIceCandidate::from(handle);
-                        // Empty `candidate.candidate()` means that all ICE
+                        // Empty `candidate.candidate()` means that all the ICE
                         // transports have finished gathering candidates.
                         //
                         // Doesn't need to be delivered onward to the remote

--- a/src/platform/dart/peer_connection.rs
+++ b/src/platform/dart/peer_connection.rs
@@ -226,11 +226,18 @@ impl RtcPeerConnection {
                     self.handle.get(),
                     Callback::from_fn_mut(move |handle: DartHandle| {
                         let candidate = PlatformIceCandidate::from(handle);
-                        h(IceCandidate {
-                            candidate: candidate.candidate(),
-                            sdp_m_line_index: candidate.sdp_m_line_index(),
-                            sdp_mid: candidate.sdp_mid(),
-                        });
+                        // Empty `candidate.candidate()` means that all ICE
+                        // transports have
+                        // finished gathering candidates.
+                        // Doesn't need to be delivered onward to the remote
+                        // peer.
+                        if !candidate.candidate().is_empty() {
+                            h(IceCandidate {
+                                candidate: candidate.candidate(),
+                                sdp_m_line_index: candidate.sdp_m_line_index(),
+                                sdp_mid: candidate.sdp_mid(),
+                            });
+                        }
                     })
                     .into_dart(),
                 );


### PR DESCRIPTION
## Synopsis

`medea` receives empty `IceCandidates`, which causes warning logs.

## Solution

Add filter for native platforms.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
