### PR TITLE
Update e2e tests for SFU refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,7 +327,7 @@ jobs:
           - linux
           # TODO: Re-enable once fixed stability on CI
           #- macos
-    runs-on: ${{ (contains('ios macos', matrix.platform) && 'macos-13')
+    runs-on: ${{ (contains('ios macos', matrix.platform) && 'macos-12')
               || (matrix.platform == 'windows' &&           'windows-latest')
               ||                                            'ubuntu-latest' }}
     steps:
@@ -335,13 +335,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
-
-      - name: Fix Python conflicts between macOS runner and Homebrew
-        run: |
-          # see https://github.com/actions/setup-python/issues/577
-          brew list -1 | grep python | while read formula; do brew unlink $formula; brew link --overwrite $formula; done
-        if: ${{ contains('ios macos', matrix.platform) }}
-
       - name: Setup Docker and Docker Compose
         run: |
           brew install colima docker docker-compose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,7 +327,7 @@ jobs:
           - linux
           # TODO: Re-enable once fixed stability on CI
           #- macos
-    runs-on: ${{ (contains('ios macos', matrix.platform) && 'macos-12')
+    runs-on: ${{ (contains('ios macos', matrix.platform) && 'macos-13')
               || (matrix.platform == 'windows' &&           'windows-latest')
               ||                                            'ubuntu-latest' }}
     steps:
@@ -355,8 +355,9 @@ jobs:
         id: simulator
         uses: futureware-tech/simulator-action@v3
         with:
-          os_version: '>=13.0'
           os: iOS
+          os_version: '>=13.0'
+          model: 'iPhone 13 Pro'
         if: ${{ matrix.platform == 'ios' }}
 
       - name: Download `medea-jason` lib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
 
 env:
   CACHE: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
-  MEDEA_BRANCH: edge
+  MEDEA_BRANCH: sfu-new-con-196
   PROTOC_VER: 23.x
   RUST_BACKTRACE: 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,6 +335,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
+
+      - name: Fix Python conflicts between macOS runner and Homebrew
+        run: |
+          # see https://github.com/actions/setup-python/issues/577
+          brew list -1 | grep python | while read formula; do brew unlink $formula; brew link --overwrite $formula; done
+        if: ${{ contains('ios macos', matrix.platform) }}
+
       - name: Setup Docker and Docker Compose
         run: |
           brew install colima docker docker-compose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,9 +362,8 @@ jobs:
         id: simulator
         uses: futureware-tech/simulator-action@v3
         with:
-          os: iOS
           os_version: '>=13.0'
-          model: 'iPhone 13 Pro'
+          os: iOS
         if: ${{ matrix.platform == 'ios' }}
 
       - name: Download `medea-jason` lib

--- a/e2e/tests/features/enable_remote_media.feature
+++ b/e2e/tests/features/enable_remote_media.feature
@@ -1,66 +1,46 @@
 Feature: Enable remote media
 
-  Scenario: `RemoteMediaTrack.on_enabled()` fires when video is enabled
+  Scenario: Enabling remote video works
     Given room with joined member Bob
     Given joined member Alice with disabled video playing
     When Alice enables remote video
-    Then `on_enabled` callback fires 1 time on Alice's remote device video track from Bob
+    Then Alice's device video remote track from Bob is enabled
 
-  Scenario: `RemoteMediaTrack.on_enabled()` fires when audio is enabled
+  Scenario: Enabling remote device video works
+    Given room with joined member Bob
+    Given joined member Alice with disabled video playing
+    When Alice enables remote device video
+    Then Alice's device video remote track from Bob is enabled
+
+  Scenario: Enabling remote audio works
     Given room with joined member Bob
     Given joined member Alice with disabled audio playing
     When Alice enables remote audio
-    Then `on_enabled` callback fires 1 time on Alice's remote audio track from Bob
+    Then Alice's audio remote track from Bob is enabled
 
-  Scenario Outline: `RemoteMediaTrack.on_enabled()` doesn't fire when track is created
+  @mesh
+  Scenario: `RemoteMediaTrack.on_enabled()` doesn't fire when track is created
     Given room with joined member Alice
     And member Bob
     When Bob joins the room
-    Then `on_enabled` callback fires <count> times on Alice's remote audio track from Bob
-    And `on_enabled` callback fires <count> times on Alice's remote device video track from Bob
+    Then `on_enabled` callback fires 0 times on Alice's remote audio track from Bob
+    And `on_enabled` callback fires 0 times on Alice's remote device video track from Bob
     And `on_enabled` callback fires 0 times on Bob's remote audio track from Alice
     And `on_enabled` callback fires 0 times on Bob's remote device video track from Alice
 
-    @mesh
-    Examples:
-      | count |
-      | 0     |
-
-    @sfu
-    Examples:
-      | count |
-      | 1     |
-
-  Scenario Outline: Remote member enables video
+  @mesh
+  Scenario: Remote member enables video
     Given room with joined member Alice
     And joined member Bob
     When Bob disables video and awaits it completes
     And Bob enables video and awaits it completes
-    Then `on_enabled` callback fires <count> times on Alice's remote device video track from Bob
+    Then `on_enabled` callback fires 1 times on Alice's remote device video track from Bob
 
-    @mesh
-    Examples:
-      | count |
-      | 1     |
-
-    @sfu
-    Examples:
-      | count |
-      | 2     |
-
-  Scenario Outline: Remote member enables audio
+  @mesh
+  Scenario: Remote member enables audio
     Given room with joined member Alice
     And joined member Bob
     When Bob disables audio and awaits it completes
     And Bob enables audio and awaits it completes
-    Then `on_enabled` callback fires <count> times on Alice's remote audio track from Bob
+    Then `on_enabled` callback fires 1 times on Alice's remote audio track from Bob
 
-    @mesh
-    Examples:
-      | count |
-      | 1     |
-
-    @sfu
-    Examples:
-      | count |
-      | 2     |

--- a/e2e/tests/features/enable_remote_media.feature
+++ b/e2e/tests/features/enable_remote_media.feature
@@ -43,4 +43,3 @@ Feature: Enable remote media
     When Bob disables audio and awaits it completes
     And Bob enables audio and awaits it completes
     Then `on_enabled` callback fires 1 times on Alice's remote audio track from Bob
-


### PR DESCRIPTION
Related to streaming/medea#196

## Synopsis

E2E test updated caused by SFU connection establishment in medea.





## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
