### PR TITLE
Expand `control-api` events

### DIFF
--- a/e2e-demo/js/index.js
+++ b/e2e-demo/js/index.js
@@ -70,7 +70,9 @@ async function createRoom(roomId, memberId) {
           credentials: { plain: 'test' },
           pipeline: pipeline,
           on_join: 'grpc://127.0.0.1:9099',
-          on_leave: 'grpc://127.0.0.1:9099'
+          on_leave: 'grpc://127.0.0.1:9099',
+          on_start: 'grpc://127.0.0.1:9099',
+          on_stop: 'grpc://127.0.0.1:9099'
         }
       }
     }
@@ -139,7 +141,9 @@ async function createMember(roomId, memberId) {
         credentials: { plain: 'test' },
         pipeline: pipeline,
         on_join: 'grpc://127.0.0.1:9099',
-        on_leave: 'grpc://127.0.0.1:9099'
+        on_leave: 'grpc://127.0.0.1:9099',
+        on_start: 'grpc://127.0.0.1:9099',
+        on_stop: 'grpc://127.0.0.1:9099'
       }
     });
   } else {
@@ -154,7 +158,9 @@ async function createMember(roomId, memberId) {
             credentials: { plain: 'test' },
             pipeline: pipeline,
             on_join: 'grpc://127.0.0.1:9099',
-            on_leave: 'grpc://127.0.0.1:9099'
+            on_leave: 'grpc://127.0.0.1:9099',
+            on_start: 'grpc://127.0.0.1:9099',
+            on_stop: 'grpc://127.0.0.1:9099'
           }
         }
       }

--- a/e2e/tests/world/mod.rs
+++ b/e2e/tests/world/mod.rs
@@ -204,6 +204,8 @@ impl World {
                     )),
                     on_join: Some("grpc://127.0.0.1:9099".to_owned()),
                     on_leave: Some("grpc://127.0.0.1:9099".to_owned()),
+                    on_start: Some("grpc://127.0.0.1:9099".to_owned()),
+                    on_stop: Some("grpc://127.0.0.1:9099".to_owned()),
                     idle_timeout: None,
                     reconnect_timeout: None,
                     ping_interval: None,

--- a/mock/control-api/src/api/member.rs
+++ b/mock/control-api/src/api/member.rs
@@ -34,6 +34,14 @@ pub struct Member {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub on_leave: Option<String>,
 
+    /// URL to which `OnStart` Control API callback will be sent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub on_start: Option<String>,
+
+    /// URL to which `OnStop` Control API callback will be sent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub on_stop: Option<String>,
+
     /// Timeout of receiving heartbeat messages from this [`Member`] via Client
     /// API. Once reached, the [`Member`] is considered being idle.
     #[serde(default, with = "humantime_serde")]
@@ -69,6 +77,8 @@ impl Member {
             credentials: self.credentials.map(Into::into),
             on_join: self.on_join.unwrap_or_default(),
             on_leave: self.on_leave.unwrap_or_default(),
+            on_start: self.on_start.unwrap_or_default(),
+            on_stop: self.on_stop.unwrap_or_default(),
             idle_timeout: self.idle_timeout.map(|d| d.try_into().unwrap()),
             reconnect_timeout: self
                 .reconnect_timeout
@@ -100,6 +110,8 @@ impl From<proto::Member> for Member {
             credentials: proto.credentials.map(Into::into),
             on_join: Some(proto.on_join).filter(|s| !s.is_empty()),
             on_leave: Some(proto.on_leave).filter(|s| !s.is_empty()),
+            on_start: Some(proto.on_start).filter(|s| !s.is_empty()),
+            on_stop: Some(proto.on_stop).filter(|s| !s.is_empty()),
             idle_timeout: proto.idle_timeout.map(|dur| dur.try_into().unwrap()),
             reconnect_timeout: proto
                 .reconnect_timeout

--- a/proto/control-api/src/control/member.rs
+++ b/proto/control-api/src/control/member.rs
@@ -58,6 +58,18 @@ pub struct Spec {
     /// [Client API]: https://tinyurl.com/266y74tf
     pub on_leave: Option<Url>,
 
+    /// [`Url`] of the callback to fire when this [`Member`] started traffic
+    /// with a media server via [Client API].
+    ///
+    /// [Client API]: https://tinyurl.com/266y74tf
+    pub on_start: Option<Url>,
+
+    /// [`Url`] of the callback to fire when this [`Member`] stopped traffic
+    /// with a media server via [Client API].
+    ///
+    /// [Client API]: https://tinyurl.com/266y74tf
+    pub on_stop: Option<Url>,
+
     /// Timeout of receiving heartbeat messages from this [`Member`] via
     /// [Client API].
     ///

--- a/proto/control-api/src/grpc/api.proto
+++ b/proto/control-api/src/grpc/api.proto
@@ -168,6 +168,12 @@ message Member {
   // URL of the callback to fire when this `Member` finishes a persistent
   // connection with a media server via Client API.
   string on_leave = 3;
+  /// URL of the callback to fire when this [`Member`] start traffic
+  /// with a media server via [Client API].
+  string on_start = 4;
+  /// URL of the callback to fire when this [`Member`] stopped traffic
+  /// with a media server via [Client API].
+  string on_stop = 5;
   // Credentials to authenticate this `Member` in Client API with.
   //
   // Plain and hashed credentials are supported. If no credentials provided,
@@ -179,23 +185,23 @@ message Member {
   // are used, so it should be appended manually on a client side.
   oneof credentials {
     // Argon2 hash of credentials.
-    string hash = 4;
+    string hash = 6;
     // Plain text credentials.
-    string plain = 5;
+    string plain = 7;
   }
   // Timeout of receiving heartbeat messages from this `Member` via Client API.
   // Once reached, this `Member` is considered being idle.
-  google.protobuf.Duration idle_timeout = 6;
+  google.protobuf.Duration idle_timeout = 8;
   // Timeout of reconnecting this `Member` via Client API.
   // Once reached, this `Member` is considered disconnected.
-  google.protobuf.Duration reconnect_timeout = 7;
+  google.protobuf.Duration reconnect_timeout = 9;
   // Interval of pinging with heartbeat messages this `Member` via Client API
   // by a media server.
   // If empty then the default interval of a media server is used, if
   // configured.
-  google.protobuf.Duration ping_interval = 8;
+  google.protobuf.Duration ping_interval = 10;
   // Media pipeline representing this `Member`.
-  map<string, Member.Element> pipeline = 9;
+  map<string, Member.Element> pipeline = 11;
 
   // Elements which Member's pipeline can contain.
   message Element {

--- a/proto/control-api/src/grpc/api.rs
+++ b/proto/control-api/src/grpc/api.rs
@@ -209,22 +209,30 @@ pub struct Member {
     /// connection with a media server via Client API.
     #[prost(string, tag = "3")]
     pub on_leave: ::prost::alloc::string::String,
+    /// / URL of the callback to fire when this \[`Member`\] start traffic
+    /// / with a media server via \[Client API\].
+    #[prost(string, tag = "4")]
+    pub on_start: ::prost::alloc::string::String,
+    /// / URL of the callback to fire when this \[`Member`\] stopped traffic
+    /// / with a media server via \[Client API\].
+    #[prost(string, tag = "5")]
+    pub on_stop: ::prost::alloc::string::String,
     /// Timeout of receiving heartbeat messages from this `Member` via Client API.
     /// Once reached, this `Member` is considered being idle.
-    #[prost(message, optional, tag = "6")]
+    #[prost(message, optional, tag = "8")]
     pub idle_timeout: ::core::option::Option<::prost_types::Duration>,
     /// Timeout of reconnecting this `Member` via Client API.
     /// Once reached, this `Member` is considered disconnected.
-    #[prost(message, optional, tag = "7")]
+    #[prost(message, optional, tag = "9")]
     pub reconnect_timeout: ::core::option::Option<::prost_types::Duration>,
     /// Interval of pinging with heartbeat messages this `Member` via Client API
     /// by a media server.
     /// If empty then the default interval of a media server is used, if
     /// configured.
-    #[prost(message, optional, tag = "8")]
+    #[prost(message, optional, tag = "10")]
     pub ping_interval: ::core::option::Option<::prost_types::Duration>,
     /// Media pipeline representing this `Member`.
-    #[prost(map = "string, message", tag = "9")]
+    #[prost(map = "string, message", tag = "11")]
     pub pipeline: ::std::collections::HashMap<
         ::prost::alloc::string::String,
         member::Element,
@@ -238,7 +246,7 @@ pub struct Member {
     /// Hashed variant only supports Argon2 hash at the moment.
     /// `Member` sid won't contain a `token` query parameter if hashed credentials
     /// are used, so it should be appended manually on a client side.
-    #[prost(oneof = "member::Credentials", tags = "4, 5")]
+    #[prost(oneof = "member::Credentials", tags = "6, 7")]
     pub credentials: ::core::option::Option<member::Credentials>,
 }
 /// Nested message and enum types in `Member`.
@@ -274,10 +282,10 @@ pub mod member {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Credentials {
         /// Argon2 hash of credentials.
-        #[prost(string, tag = "4")]
+        #[prost(string, tag = "6")]
         Hash(::prost::alloc::string::String),
         /// Plain text credentials.
-        #[prost(string, tag = "5")]
+        #[prost(string, tag = "7")]
         Plain(::prost::alloc::string::String),
     }
 }

--- a/proto/control-api/src/grpc/callback.proto
+++ b/proto/control-api/src/grpc/callback.proto
@@ -21,6 +21,64 @@ message Request {
   oneof event {
     OnJoin on_join = 3;
     OnLeave on_leave = 4;
+    OnStart on_start = 5;
+    OnStop on_stop = 6;
+  }
+}
+
+// Media type of the traffic which starts/stops flowing in some Endpoint.
+enum MediaType {
+  /// Started/stopped audio traffic.
+  AUDIO = 0;
+
+  /// Started/stopped video traffic.
+  VIDEO = 1;
+
+  /// Started/stopped audio and video traffic.
+  BOTH = 2;
+}
+
+// Media direction of the Endpoint for which OnStart or OnStop Control API callback
+// was received.
+enum MediaDirection {
+  // Endpoint is a publisher.
+  PUBLISH = 0;
+
+  // Endpoint is a player.
+  PLAY = 1;
+}
+
+// Event which fires when Endpoint starts sending/receiving media traffic.
+message OnStart {
+  // Media type of the traffic which starts flowing in some Endpoint.
+  MediaType media_type = 1;
+
+  // Media direction of the Endpoint for which this callback was received.
+  MediaDirection media_direction = 2;
+}
+
+// Event which fires when Endpoint stops sending/receiving media traffic.
+message OnStop {
+  /// Media type of the traffic which stops flowing in some Endpoint.
+  MediaType media_type = 1;
+  /// Media Endpoint for which this callback was received.
+  MediaDirection media_direction = 2;
+  // Reason of why Endpoint was stopped.
+  Reason reason = 3;
+
+  // Reason of why some Endpoint was stopped.
+  enum Reason {
+    // All traffic of some Endpoint was stopped flowing.
+    TRAFFIC_NOT_FLOWING = 0;
+
+    // Endpoint was muted.
+    MUTED = 1;
+
+    // Some traffic flows within Endpoint, but incorrectly.
+    WRONG_TRAFFIC_FLOWING = 2;
+
+    // Traffic stopped because Endpoint was removed.
+    ENDPOINT_REMOVED = 3;
   }
 }
 

--- a/proto/control-api/src/grpc/callback.rs
+++ b/proto/control-api/src/grpc/callback.rs
@@ -9,7 +9,7 @@ pub struct Request {
     #[prost(string, tag = "2")]
     pub at: ::prost::alloc::string::String,
     /// Occurred event.
-    #[prost(oneof = "request::Event", tags = "3, 4")]
+    #[prost(oneof = "request::Event", tags = "3, 4, 5, 6")]
     pub event: ::core::option::Option<request::Event>,
 }
 /// Nested message and enum types in `Request`.
@@ -22,6 +22,85 @@ pub mod request {
         OnJoin(super::OnJoin),
         #[prost(message, tag = "4")]
         OnLeave(super::OnLeave),
+        #[prost(message, tag = "5")]
+        OnStart(super::OnStart),
+        #[prost(message, tag = "6")]
+        OnStop(super::OnStop),
+    }
+}
+/// Event which fires when Endpoint starts sending/receiving media traffic.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OnStart {
+    /// Media type of the traffic which starts flowing in some Endpoint.
+    #[prost(enumeration = "MediaType", tag = "1")]
+    pub media_type: i32,
+    /// Media direction of the Endpoint for which this callback was received.
+    #[prost(enumeration = "MediaDirection", tag = "2")]
+    pub media_direction: i32,
+}
+/// Event which fires when Endpoint stops sending/receiving media traffic.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OnStop {
+    /// / Media type of the traffic which stops flowing in some Endpoint.
+    #[prost(enumeration = "MediaType", tag = "1")]
+    pub media_type: i32,
+    /// / Media Endpoint for which this callback was received.
+    #[prost(enumeration = "MediaDirection", tag = "2")]
+    pub media_direction: i32,
+    /// Reason of why Endpoint was stopped.
+    #[prost(enumeration = "on_stop::Reason", tag = "3")]
+    pub reason: i32,
+}
+/// Nested message and enum types in `OnStop`.
+pub mod on_stop {
+    /// Reason of why some Endpoint was stopped.
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
+    #[repr(i32)]
+    pub enum Reason {
+        /// All traffic of some Endpoint was stopped flowing.
+        TrafficNotFlowing = 0,
+        /// Endpoint was muted.
+        Muted = 1,
+        /// Some traffic flows within Endpoint, but incorrectly.
+        WrongTrafficFlowing = 2,
+        /// Traffic stopped because Endpoint was removed.
+        EndpointRemoved = 3,
+    }
+    impl Reason {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Reason::TrafficNotFlowing => "TRAFFIC_NOT_FLOWING",
+                Reason::Muted => "MUTED",
+                Reason::WrongTrafficFlowing => "WRONG_TRAFFIC_FLOWING",
+                Reason::EndpointRemoved => "ENDPOINT_REMOVED",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "TRAFFIC_NOT_FLOWING" => Some(Self::TrafficNotFlowing),
+                "MUTED" => Some(Self::Muted),
+                "WRONG_TRAFFIC_FLOWING" => Some(Self::WrongTrafficFlowing),
+                "ENDPOINT_REMOVED" => Some(Self::EndpointRemoved),
+                _ => None,
+            }
+        }
     }
 }
 /// Empty response of the `Callback` service.
@@ -90,6 +169,69 @@ pub mod on_leave {
                 "SHUTDOWN" => Some(Self::Shutdown),
                 _ => None,
             }
+        }
+    }
+}
+/// Media type of the traffic which starts/stops flowing in some Endpoint.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum MediaType {
+    /// / Started/stopped audio traffic.
+    Audio = 0,
+    /// / Started/stopped video traffic.
+    Video = 1,
+    /// / Started/stopped audio and video traffic.
+    Both = 2,
+}
+impl MediaType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            MediaType::Audio => "AUDIO",
+            MediaType::Video => "VIDEO",
+            MediaType::Both => "BOTH",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "AUDIO" => Some(Self::Audio),
+            "VIDEO" => Some(Self::Video),
+            "BOTH" => Some(Self::Both),
+            _ => None,
+        }
+    }
+}
+/// Media direction of the Endpoint for which OnStart or OnStop Control API callback
+/// was received.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum MediaDirection {
+    /// Endpoint is a publisher.
+    Publish = 0,
+    /// Endpoint is a player.
+    Play = 1,
+}
+impl MediaDirection {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            MediaDirection::Publish => "PUBLISH",
+            MediaDirection::Play => "PLAY",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "PUBLISH" => Some(Self::Publish),
+            "PLAY" => Some(Self::Play),
+            _ => None,
         }
     }
 }

--- a/proto/control-api/src/grpc/convert/api.rs
+++ b/proto/control-api/src/grpc/convert/api.rs
@@ -412,6 +412,14 @@ impl TryFrom<proto::Member> for Member {
                     .then(|| member.on_leave.parse())
                     .transpose()
                     .map_err(CallbackUrlParseError::from)?,
+                on_start: (!member.on_start.is_empty())
+                    .then(|| member.on_start.parse())
+                    .transpose()
+                    .map_err(CallbackUrlParseError::from)?,
+                on_stop: (!member.on_stop.is_empty())
+                    .then(|| member.on_stop.parse())
+                    .transpose()
+                    .map_err(CallbackUrlParseError::from)?,
                 idle_timeout,
                 reconnect_timeout,
                 ping_interval,
@@ -435,6 +443,16 @@ impl From<Member> for proto::Member {
             on_leave: member
                 .spec
                 .on_leave
+                .as_ref()
+                .map_or_else(String::default, ToString::to_string),
+            on_start: member
+                .spec
+                .on_start
+                .as_ref()
+                .map_or_else(String::default, ToString::to_string),
+            on_stop: member
+                .spec
+                .on_stop
                 .as_ref()
                 .map_or_else(String::default, ToString::to_string),
             idle_timeout: member


### PR DESCRIPTION

## Synopsis

`Control-api` extension to support `OnStop`, `OnStart` event.


## Solution

Implement `OnStop`, `OnStart` events.



## Checklist

- Created PR:
    - [ ] In [draft mode][l:1]
    - [ ] Name contains issue reference
    - [ ] Has type and `k::` labels applied
    - [ ] Has assignee
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
