### PR TITLE
Fix Control API gRPC gen files unexpected regeneration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
 
 env:
   CACHE: ${{ !contains(github.event.head_commit.message, '[fresh ci]') }}
-  MEDEA_TAG: rtp-mode-svc
+  MEDEA_TAG: edge
   PROTOC_VER: 23.x
   RUST_BACKTRACE: 1
 

--- a/proto/control-api/Cargo.toml
+++ b/proto/control-api/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["api-bindings", "network-programming"]
 include = ["/src/", "/build.rs", "/CHANGELOG.md", "/LICENSE.md"]
 
 [features]
+default = ["client", "server"]
 client = []
 server = []
 direct = ["dep:futures"]


### PR DESCRIPTION
## Synopsis

When working with `medea-jason` project, sometimes when you run something like `cargo check`, files related to the Control API gRPC are regenerated. And some files can be deleted and this can be accidentally committed to the branch. This changes are not correct, because this files should live in the git index, but because of the feature flags, they're regenerated incorrectly.




## Solution

We can just add `server` and `client` features to the default set of features of `medea-control-api-proto` crate. So when we run `cargo check` without any arguments, it will compile with this features. This will not remove required files. This fix works, but it needs to be checked, because it can cause some unexpected behaviour.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
