### PR TITLE
Extend `RtcIceCandidatePairStats` with id fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ All user visible changes to this project will be documented in this file. This p
 - Logging:
     - Exceptions thrown from Dart callbacks called by Rust ([#138]).
 - Monitoring:
-    - `IceCandidateError` metric sending to server ([#151]).
+    - `IceCandidateError` metric sending to server ([#151]);
+    - `transport_id`, `local_candidate_id` and `remote_candidate_id` to the `RtcIceCandidatePairStats` ([#172]).
 
 ### Fixed
 
@@ -35,6 +36,7 @@ All user visible changes to this project will be documented in this file. This p
 [#151]: /../../pull/151
 [#162]: /../../pull/162
 [#163]: /../../pull/163
+[#172]: /../../pull/172
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All user visible changes to this project will be documented in this file. This p
     - Exceptions thrown from Dart callbacks called by Rust ([#138]).
 - Monitoring:
     - `IceCandidateError` metric sending to server ([#151]);
-    - `transport_id`, `local_candidate_id` and `remote_candidate_id` to the `RtcIceCandidatePairStats` ([#172]).
+    - `transport_id`, `local_candidate_id` and `remote_candidate_id` to `RtcIceCandidatePairStats` ([#172]).
 
 ### Fixed
 

--- a/proto/client-api/src/stats.rs
+++ b/proto/client-api/src/stats.rs
@@ -825,6 +825,21 @@ pub enum ReceiverStatsKind {
 #[derive(Clone, Debug, Deserialize, Hash, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RtcIceCandidatePairStats {
+    /// It is a unique identifier that is associated to the object that was
+    /// inspected to produce the [`RtcTransportStats`] associated with this
+    /// candidate pair.
+    pub transport_id: Option<String>,
+
+    /// It is a unique identifier that is associated to the object that was
+    /// inspected to produce the [`RtcIceCandidateStats`] for the local
+    /// candidate associated with this candidate pair.
+    pub local_candidate_id: Option<String>,
+
+    /// It is a unique identifier that is associated to the object that was
+    /// inspected to produce the [`RtcIceCandidateStats`] for the remote
+    /// candidate associated with this candidate pair.
+    pub remote_candidate_id: Option<String>,
+
     /// State of the checklist for the local and remote candidates in a pair.
     pub state: IceCandidatePairState,
 

--- a/proto/client-api/src/stats.rs
+++ b/proto/client-api/src/stats.rs
@@ -825,19 +825,18 @@ pub enum ReceiverStatsKind {
 #[derive(Clone, Debug, Deserialize, Hash, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RtcIceCandidatePairStats {
-    /// It is a unique identifier that is associated to the object that was
-    /// inspected to produce the [`RtcTransportStats`] associated with this
-    /// candidate pair.
+    /// Unique identifier associated to the object that was inspected to produce
+    /// the [`RtcTransportStats`] associated with this candidates pair.
     pub transport_id: Option<String>,
 
-    /// It is a unique identifier that is associated to the object that was
-    /// inspected to produce the [`RtcIceCandidateStats`] for the local
-    /// candidate associated with this candidate pair.
+    /// Unique identifier associated to the object that was inspected to produce
+    /// the [`RtcIceCandidateStats`] for the local candidate associated with
+    /// this candidates pair.
     pub local_candidate_id: Option<String>,
 
-    /// It is a unique identifier that is associated to the object that was
-    /// inspected to produce the [`RtcIceCandidateStats`] for the remote
-    /// candidate associated with this candidate pair.
+    /// Unique identifier associated to the object that was inspected to produce
+    /// the [`RtcIceCandidateStats`] for the remote candidate associated with
+    /// this candidates pair.
     pub remote_candidate_id: Option<String>,
 
     /// State of the checklist for the local and remote candidates in a pair.

--- a/proto/client-api/src/stats.rs
+++ b/proto/client-api/src/stats.rs
@@ -825,18 +825,19 @@ pub enum ReceiverStatsKind {
 #[derive(Clone, Debug, Deserialize, Hash, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RtcIceCandidatePairStats {
-    /// Unique identifier associated to the object that was inspected to produce
-    /// the [`RtcTransportStats`] associated with this candidates pair.
+    /// Unique identifier associated to the object that was inspected to
+    /// produce the [`RtcTransportStats`] associated with this candidates
+    /// pair.
     pub transport_id: Option<String>,
 
-    /// Unique identifier associated to the object that was inspected to produce
-    /// the [`RtcIceCandidateStats`] for the local candidate associated with
-    /// this candidates pair.
+    /// Unique identifier associated to the object that was inspected to
+    /// produce the [`RtcIceCandidateStats`] for the local candidate
+    /// associated with this candidates pair.
     pub local_candidate_id: Option<String>,
 
-    /// Unique identifier associated to the object that was inspected to produce
-    /// the [`RtcIceCandidateStats`] for the remote candidate associated with
-    /// this candidates pair.
+    /// Unique identifier associated to the object that was inspected to
+    /// produce the [`RtcIceCandidateStats`] for the remote candidate
+    /// associated with this candidates pair.
     pub remote_candidate_id: Option<String>,
 
     /// State of the checklist for the local and remote candidates in a pair.


### PR DESCRIPTION
## Synopsis

As a part of RTC stats processing implementation on server, it was discovered that `RtcIceCandidatePairStats` is unusable without `localCandidateId` and `remoteCandidateId`. So this PR adds this fields to the `RtcIceCandidatePairStats`.




## Solution

Add `local_candidate_id` and `remote_candidate_id` fields to the `medea_client_api_proto::stats::RtcIceCandidatePairStats`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
