### PR TITLE
Fix screensharing on desktop platforms 

### DIFF
--- a/flutter/example/pubspec.lock
+++ b/flutter/example/pubspec.lock
@@ -286,18 +286,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -334,10 +334,10 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   medea_flutter_webrtc:
     dependency: "direct main"
     description:
@@ -357,10 +357,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   mime:
     dependency: transitive
     description:
@@ -546,10 +546,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "2419f20b0c8677b2d67c8ac4d1ac7372d862dc6c460cdbb052b40155408cd794"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.1"
   tuple:
     dependency: transitive
     description:
@@ -586,10 +586,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "360c4271613beb44db559547d02f8b0dc044741d0eeb9aa6ccdb47e8ec54c63a"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.3"
   watcher:
     dependency: transitive
     description:

--- a/flutter/lib/src/native/platform/constraints.dart
+++ b/flutter/lib/src/native/platform/constraints.dart
@@ -20,6 +20,7 @@ void registerFunctions(DynamicLibrary dl) {
     setAudioConstraintValue: Pointer.fromFunction(_setAudioConstraintValue),
     setVideoConstraint: Pointer.fromFunction(_setVideoConstraint),
     setAudioConstraint: Pointer.fromFunction(_setAudioConstraint),
+    setDisplayVideoConstraint: Pointer.fromFunction(_setDisplayVideoConstraint),
   );
 }
 
@@ -114,6 +115,22 @@ void _setAudioConstraintValue(Object cons, int kind, ForeignValue value) {
 /// [DeviceConstraints].
 void _setVideoConstraint(Object cons, int type, Object video) {
   cons as webrtc.DeviceConstraints;
+  video as webrtc.DeviceVideoConstraints;
+
+  switch (ConstraintType.values[type]) {
+    case ConstraintType.optional:
+      cons.video.optional = video;
+      break;
+    case ConstraintType.mandatory:
+      cons.video.mandatory = video;
+      break;
+  }
+}
+
+/// Specifies the provided nature and settings of a video track to the given
+/// [DisplayConstraints].
+void _setDisplayVideoConstraint(Object cons, int type, Object video) {
+  cons as webrtc.DisplayConstraints;
   video as webrtc.DeviceVideoConstraints;
 
   switch (ConstraintType.values[type]) {

--- a/flutter/lib/src/native/platform/constraints.g.dart
+++ b/flutter/lib/src/native/platform/constraints.g.dart
@@ -17,13 +17,15 @@ void registerFunction(
   required Pointer<NativeFunction<Void Function(Handle, Int64, Handle)>>
       setVideoConstraint,
   required Pointer<NativeFunction<Void Function(Handle, Int64, Handle)>>
+      setDisplayVideoConstraint,
+  required Pointer<NativeFunction<Void Function(Handle, Int64, Handle)>>
       setAudioConstraint,
 }) {
   dl.lookupFunction<
       Void Function(Pointer, Pointer, Pointer, Pointer, Pointer, Pointer,
-          Pointer, Pointer),
+          Pointer, Pointer, Pointer),
       void Function(Pointer, Pointer, Pointer, Pointer, Pointer, Pointer,
-          Pointer, Pointer)>('register_constraints')(
+          Pointer, Pointer, Pointer)>('register_constraints')(
     initDeviceConstraints,
     initDisplayConstraints,
     newVideoConstraints,
@@ -31,6 +33,7 @@ void registerFunction(
     setVideoConstraintValue,
     setAudioConstraintValue,
     setVideoConstraint,
+    setDisplayVideoConstraint,
     setAudioConstraint,
   );
 }

--- a/src/platform/dart/constraints.rs
+++ b/src/platform/dart/constraints.rs
@@ -76,6 +76,17 @@ mod constraints {
             video: Dart_Handle,
         );
 
+        /// Specifies the provided nature and settings of a display `video`
+        /// [MediaStreamTrack][1] to the given [MediaStreamConstraints][0].
+        ///
+        /// [0]: https://w3.org/TR/mediacapture-streams#mediastreamconstraints
+        /// [1]: https://w3.org/TR/mediacapture-streams#mediastreamtrack
+        pub fn set_display_video_constraint(
+            constraints: Dart_Handle,
+            ty: i64,
+            video: Dart_Handle,
+        );
+
         /// Specifies the provided nature and settings of an `audio`
         /// [MediaStreamTrack][1] to the given [MediaStreamConstraints][0].
         ///
@@ -239,14 +250,14 @@ impl DisplayMediaStreamConstraints {
     pub fn video(&mut self, video: DisplayVideoTrackConstraints) {
         let video = MediaTrackConstraints::from(video);
         unsafe {
-            constraints::set_video_constraint(
+            constraints::set_display_video_constraint(
                 self.0.get(),
                 ConstraintType::Mandatory as i64,
                 video.mandatory.get(),
             );
         }
         unsafe {
-            constraints::set_video_constraint(
+            constraints::set_display_video_constraint(
                 self.0.get(),
                 ConstraintType::Optional as i64,
                 video.optional.get(),


### PR DESCRIPTION
## Synopsis

[This](https://github.com/instrumentisto/medea-jason/pull/169/files#diff-8c2bc3e21f14a9adcafeaa161425370a1218fb93f341d7adee8dfa71cbed1e9cR113) change introduced strict type checks which caused cast exception and failure to properly set screen-sharing media constraints.




## Solution

Add different function with correct type casts.




## Checklist

- Created PR:
    - [ ] In [draft mode][l:1]
    - [ ] Name contains issue reference
    - [ ] Has type and `k::` labels applied
    - [ ] Has assignee
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
