### PR TITLE
Fix multi-room functional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All user visible changes to this project will be documented in this file. This p
 ### BC Breaks
 
 - Minimal supported version of `medea-client-api-proto` is `0.6.0` ([#151]).
+- Library API:
+    - Removed `with_rpc_client()` constructor and added `WebSocketRpcClient` as argument to `new()` constructor in `Jason` ([#175]).
 
 ### Added
 
@@ -42,6 +44,7 @@ All user visible changes to this project will be documented in this file. This p
 [#166]: /../../pull/166
 [#167]: /../../pull/167
 [#172]: /../../pull/172
+[#175]: /../../pull/175
 
 
 

--- a/src/api/dart/api.rs
+++ b/src/api/dart/api.rs
@@ -479,7 +479,7 @@ pub fn on_panic(cb: DartOpaque) -> SyncReturn<()> {
 /// Instantiates a new [`Jason`] interface to interact with this library.
 #[must_use]
 pub fn jason_new() -> SyncReturn<RustOpaque<Jason>> {
-    SyncReturn(RustOpaque::new(Jason::new()))
+    SyncReturn(RustOpaque::new(Jason::new(None)))
 }
 
 /// Creates a new [`Room`] and returns its [`RoomHandle`].

--- a/src/api/wasm/jason.rs
+++ b/src/api/wasm/jason.rs
@@ -22,7 +22,7 @@ impl Jason {
     #[must_use]
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
-        Self(jason::Jason::new())
+        Self(jason::Jason::new(None))
     }
 
     /// Creates a new `Room` and returns its [`RoomHandle`].

--- a/src/jason.rs
+++ b/src/jason.rs
@@ -13,13 +13,6 @@ use crate::{
     },
 };
 
-/// Creates new RPC connection with a media server.
-fn create_rpc_client() -> Rc<WebSocketRpcClient> {
-    Rc::new(WebSocketRpcClient::new(Box::new(|| {
-        Rc::new(platform::WebSocketRpcTransport::new())
-    })))
-}
-
 /// General library interface.
 ///
 /// Responsible for managing shared transports, local media and room
@@ -74,12 +67,11 @@ impl Jason {
     /// Creates a new [`Room`] and returns its [`RoomHandle`].
     #[must_use]
     pub fn init_room(&self) -> RoomHandle {
-        let rpc = self
-            .0
-            .borrow()
-            .rpc
-            .clone()
-            .unwrap_or_else(create_rpc_client);
+        let rpc = self.0.borrow().rpc.clone().unwrap_or_else(|| {
+            Rc::new(WebSocketRpcClient::new(Box::new(|| {
+                Rc::new(platform::WebSocketRpcTransport::new())
+            })))
+        });
         self.inner_init_room(WebSocketRpcSession::new(rpc))
     }
 

--- a/src/jason.rs
+++ b/src/jason.rs
@@ -52,7 +52,7 @@ struct Inner {
 impl Jason {
     /// Instantiates a new [`Jason`] interface to interact with this library.
     ///
-    /// If [`WebSocketRpcClient`] is provided then [`Jason`] will reuse it for
+    /// If [`WebSocketRpcClient`] is provided, then [`Jason`] will reuse it for
     /// the all [`Room`]s created in this [`Jason`].
     ///
     /// If [`WebSocketRpcClient`] is not provided, then new separate
@@ -106,12 +106,6 @@ impl Jason {
             let room = this.rooms.swap_remove(i);
             room.set_close_reason(ClientDisconnect::RoomClosed.into());
             drop(room);
-            if this.rooms.is_empty() && this.rpc.is_some() {
-                this.rpc =
-                    Some(Rc::new(WebSocketRpcClient::new(Box::new(|| {
-                        Rc::new(platform::WebSocketRpcTransport::new())
-                    }))));
-            }
         }
     }
 

--- a/src/jason.rs
+++ b/src/jason.rs
@@ -79,7 +79,7 @@ impl Jason {
             .borrow()
             .rpc
             .clone()
-            .unwrap_or_else(|| create_rpc_client());
+            .unwrap_or_else(create_rpc_client);
         self.inner_init_room(WebSocketRpcSession::new(rpc))
     }
 

--- a/src/jason.rs
+++ b/src/jason.rs
@@ -35,20 +35,20 @@ struct Inner {
     /// Connection with a media server.
     ///
     /// [`Jason`] will reuse this [`WebSocketRpcClient`] for each [`Room`] if
-    /// it's `Some`.
+    /// it's [`Some`].
     ///
     /// New [`WebSocketRpcClient`] will be created for each [`Room`] if it's
-    /// `None`.
+    /// [`None`].
     rpc: Option<Rc<WebSocketRpcClient>>,
 }
 
 impl Jason {
     /// Instantiates a new [`Jason`] interface to interact with this library.
     ///
-    /// If [`WebSocketRpcClient`] is provided, then [`Jason`] will reuse it for
-    /// the all [`Room`]s created in this [`Jason`].
+    /// If a [`WebSocketRpcClient`] is provided, then [`Jason`] will reuse it
+    /// for all the [`Room`]s created in this [`Jason`].
     ///
-    /// If [`WebSocketRpcClient`] is not provided, then new separate
+    /// If [`WebSocketRpcClient`] is not provided, then a new separate
     /// [`WebSocketRpcClient`] will be created for each [`Room`].
     #[must_use]
     pub fn new(rpc: Option<Rc<WebSocketRpcClient>>) -> Self {

--- a/tests/room/mod.rs
+++ b/tests/room/mod.rs
@@ -53,7 +53,7 @@ async fn only_one_strong_rpc_rc_exists() {
         let transport = Rc::new(transport);
         transport as Rc<dyn RpcTransport>
     })));
-    let jason = api::Jason::from(Jason::with_rpc_client(ws.clone()));
+    let jason = api::Jason::from(Jason::new(Some(ws.clone())));
 
     let room = jason.init_room();
     room.on_failed_local_media(Closure::once_into_js(|| {}).into())
@@ -106,7 +106,7 @@ async fn rpc_dropped_on_jason_dispose() {
         let transport = Rc::new(transport);
         transport as Rc<dyn RpcTransport>
     })));
-    let jason = api::Jason::from(Jason::with_rpc_client(ws));
+    let jason = api::Jason::from(Jason::new(Some(ws)));
 
     let room = jason.init_room();
     room.on_failed_local_media(Closure::once_into_js(|| {}).into())
@@ -162,7 +162,7 @@ async fn room_dispose_works() {
             transport as Rc<dyn RpcTransport>
         })
     }));
-    let jason = api::Jason::from(Jason::with_rpc_client(ws));
+    let jason = api::Jason::from(Jason::new(Some(ws)));
 
     let room = jason.init_room();
     room.on_failed_local_media(Closure::once_into_js(|| {}).into())
@@ -296,7 +296,7 @@ async fn room_closes_on_rpc_transport_close() {
             transport as Rc<dyn RpcTransport>
         }
     })));
-    let jason = api::Jason::from(Jason::with_rpc_client(ws));
+    let jason = api::Jason::from(Jason::new(Some(ws)));
 
     let room = jason.init_room();
     room.on_failed_local_media(Closure::once_into_js(|| {}).into())


### PR DESCRIPTION
## Synopsis

The issue occurs when a `RoomHandle` is created and joined, another `RoomHandle` is created without joining, and then the first `RoomHandle` is closed. Any operations on the second `RoomHandle` (such as `unmuteAudio` or `join`) result in an error. This happens on both macOS and in the browser (during in-window calls). Currently, the error originates from the `unmuteAudio` method, but it will also occur from `joinRoom` if no other actions are taken.




## Solution

This issue happens, because Jason has support for reusing one WebSocket for multiple `Room`s, but it looks unsupported on the server side. It can be implemented, but this feature doesn't make too much difference, so best solution at this moment is just to create new WebSocket for each `Room`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
