### PR TITLE
Panic on unhandled Dart exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All user visible changes to this project will be documented in this file. This p
 - `ConnectionHandle.on_remote_track_added` callback might be called twice for the same track ([#162]).
 - `RemoteMediaTrack.on_media_direction_changed` callback might not be called on direction update ([#162]).
 - Segfault on Dart isolate shutdown ([#163]).
+- Exception in Dart code might be ignored by Rust caller ([#176]).
 
 [#135]: /../../pull/135
 [#138]: /../../pull/138
@@ -45,6 +46,7 @@ All user visible changes to this project will be documented in this file. This p
 [#167]: /../../pull/167
 [#172]: /../../pull/172
 [#175]: /../../pull/175
+[#176]: /../../pull/176
 
 
 

--- a/crates/medea-macro/src/dart_bridge.rs
+++ b/crates/medea-macro/src/dart_bridge.rs
@@ -338,8 +338,8 @@ impl<'a> IdentGenerator<'a> {
         )
     }
 
-    /// Returns a [`syn::Ident`] for the [`FnExpander`]'s error setter
-    /// function name.
+    /// Returns a [`syn::Ident`] for the [`FnExpander`]'s error setter function
+    /// name.
     ///
     /// Generates something like `peer_connection__create_offer__set_error`.
     fn error_setter_name(&self) -> syn::Ident {
@@ -376,8 +376,9 @@ struct FnExpander {
     /// [`syn::FnArg`]s of extern Dart function.
     input_args: Punctuated<syn::FnArg, token::Comma>,
 
-    /// [`syn::ReturnType`] of the extern Dart function. This is always a
-    /// [`Result`].
+    /// [`syn::ReturnType`] of the extern Dart function.
+    ///
+    /// This is always a [`Result`].
     ret_ty: syn::ReturnType,
 
     /// [`Result::Ok`] type of the functions return type.
@@ -422,7 +423,7 @@ impl FnExpander {
         let ret_ok_ty = {
             let err = Err(syn::Error::new(
                 item.sig.output.span(),
-                "Must return `Result<T, platform::Error>`",
+                "must return `Result<T, platform::Error>`",
             ));
 
             let syn::ReturnType::Type(_, ret_ty) = item.sig.output.clone()
@@ -470,7 +471,7 @@ impl FnExpander {
                     } else {
                         Err(syn::Error::new(
                         attr.span(),
-                        "Only #[doc] attributes supported on extern functions",
+                        "only #[doc] attributes supported on extern functions",
                     ))
                     }
                 })
@@ -554,16 +555,15 @@ impl FnExpander {
     /// # Example of generated code
     ///
     /// ```ignore
-    /// pub unsafe fn create_offer(peer: Dart_Handle) -> Result<
-    ///                                                     Dart_Handle,
-    ///                                                     Error
-    ///                                                  > {
-    ///   let res =
-    ///     (PEER_CONNECTION__CREATE_OFFER__FUNCTION.assume_init_ref())(peer);
+    /// pub unsafe fn create_offer(
+    ///     peer: Dart_Handle,
+    /// ) -> Result<Dart_Handle, Error> {
+    ///     let res =
+    ///       (PEER_CONNECTION__CREATE_OFFER__FUNCTION.assume_init_ref())(peer);
     ///
-    ///   if let Some(e) = PEER_CONNECTION__CREATE_OFFER__ERROR.take()
+    ///     if let Some(e) = PEER_CONNECTION__CREATE_OFFER__ERROR.take()
     ///         { Err(e) } else { Ok(res) }
-    ///  }
+    /// }
     /// ```
     fn gen_caller_fn(&self) -> TokenStream {
         let doc_attrs = &self.doc_attrs;

--- a/crates/medea-macro/src/dart_bridge.rs
+++ b/crates/medea-macro/src/dart_bridge.rs
@@ -597,7 +597,7 @@ impl FnExpander {
         }
     }
 
-    /// Generates `static mut` for the extern Dart function pointer storing.
+    /// Generates an error slot for this [`FnExpander`].
     ///
     /// # Example of generated code
     ///
@@ -612,22 +612,28 @@ impl FnExpander {
         }
     }
 
-    /// Generates Dart function caller for Rust.
+    /// Generates an error setter extern function.
     ///
     /// # Example of generated code
     ///
     /// ```ignore
-    /// static mut PEER_CONNECTION__CREATE_OFFER__ERROR: Option<Error> = None;
+    /// #[no_mangle]
+    /// pub unsafe extern "C" fn peer_connection__connection_state__set_error(
+    ///     err: Dart_Handle
+    /// ) {
+    ///     PEER_CONNECTION__CONNECTION_STATE__ERROR =
+    ///         Some(Error::from_handle(err));
+    /// }
     /// ```
     fn gen_error_setter(&self) -> TokenStream {
-        let doc_attrs = &self.doc_attrs;
-        let name = &self.error_setter_ident;
+        let doc = format!("Error setter for the `{}` function", self.ident);
+        let fn_name = &self.error_setter_ident;
         let error_slot = &self.error_slot_ident;
 
         quote! {
-            #( #doc_attrs )*
+            #[doc = #doc]
             #[no_mangle]
-            pub unsafe extern "C" fn #name(err: Dart_Handle) {
+            pub unsafe extern "C" fn #fn_name(err: Dart_Handle) {
                 #error_slot = Some(Error::from_handle(err));
             }
         }

--- a/crates/medea-macro/src/dart_bridge.rs
+++ b/crates/medea-macro/src/dart_bridge.rs
@@ -206,7 +206,7 @@ impl ModExpander {
             .iter()
             .map(|f| FnRegistrationBuilder {
                 inputs: f.input_args.iter().cloned().collect(),
-                output: f.ret_ty.clone(),
+                output: f.ret_ok_ty.clone(),
                 name: f.ident.clone(),
                 error_setter_ident: f.error_setter_ident.clone(),
             })

--- a/crates/medea-macro/src/dart_codegen.rs
+++ b/crates/medea-macro/src/dart_codegen.rs
@@ -154,6 +154,8 @@ impl DartType {
         }
     }
 
+    /// Converts this [`DartType`] to the string representation that can be
+    /// used in Dart code.
     pub(crate) const fn to_dart_type(self) -> &'static str {
         match self {
             Self::Void => "void",
@@ -311,6 +313,7 @@ impl TryFrom<FnRegistrationBuilder> for FnRegistration {
             })
             .collect::<syn::Result<_>>()?;
 
+        // asdasdasdasd
         let syn::ReturnType::Type(_, res) = from.output else {
             // Must return Result error
             unreachable!("0000 {:?}", from.output);

--- a/crates/medea-macro/src/dart_codegen.rs
+++ b/crates/medea-macro/src/dart_codegen.rs
@@ -524,8 +524,7 @@ impl DartCodegen {
         Ok(())
     }
 
-    /// Generates variables that store Dart bindings to Rust functions that
-    /// save execution errors.
+    /// Generates code that convert Dart function to a C function pointers.
     ///
     /// # Example of generated code
     ///
@@ -564,15 +563,17 @@ impl DartCodegen {
         Ok(())
     }
 
-    /// Generates variables that store Dart bindings to Rust functions that
-    /// save execution errors.
+    /// Generates code that performs lookup of Rust-side error setter functions.
     ///
     /// # Example of generated code
     ///
     /// ```ignore
-    /// _ErrorSetterFnDart? _peer_connection__rollback__set_error;
-    /// _ErrorSetterFnDart? _peer_connection__get_stats__set_error;
-    /// _ErrorSetterFnDart? _peer_connection__on_track__set_error;
+    ///   _peer_connection__ice_connection_state__set_error =
+    ///       dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+    ///           'peer_connection__ice_connection_state__set_error');
+    ///   _peer_connection__on_connection_state_change__set_error =
+    ///       dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+    ///           'peer_connection__on_connection_state_change__set_error');
     /// ```
     fn gen_set_error_lookup<T: Write>(&self, out: &mut T) -> fmt::Result {
         for f in &self.registrators {

--- a/crates/medea-macro/src/dart_codegen.rs
+++ b/crates/medea-macro/src/dart_codegen.rs
@@ -115,7 +115,7 @@ impl DartType {
         }
     }
 
-    /// Converts this [`DartType`] to the string representation that can be
+    /// Converts this [`DartType`] into the string representation that can be
     /// used in Dart code.
     pub(crate) const fn to_dart_type(self) -> &'static str {
         match self {
@@ -135,8 +135,9 @@ impl DartType {
         }
     }
 
-    /// String representing the default value of this [`DartType`] intended to
-    /// be used in return statement if the function have completed with error.
+    /// Returns a string representing the default value of this [`DartType`],
+    /// intended to be used in return statements if the function has completed
+    /// with an error.
     pub(crate) const fn default_value(self) -> &'static str {
         match self {
             Self::Void => "",
@@ -154,8 +155,8 @@ impl DartType {
         }
     }
 
-    /// String representing the value that should be passed as
-    /// `exceptionalReturn` argument of [Pointer.fromFunction][1] method.
+    /// Returns a string representing the value that should be passed as the
+    /// `exceptionalReturn` argument of the [Pointer.fromFunction][1] method.
     ///
     /// [1]: https://api.dart.dev/stable/dart-ffi/Pointer/fromFunction.html
     pub(crate) const fn exceptional_return(self) -> &'static str {
@@ -185,16 +186,16 @@ impl DartType {
         let syn::PathArguments::AngleBracketed(bracketed) = args else {
             return Err(syn::Error::new(
                 args.span(),
-                "Unsupported `NonNull` path arguments",
+                "unsupported `NonNull` path arguments",
             ));
         };
 
         match bracketed.args.last().ok_or_else(|| {
-            syn::Error::new(bracketed.span(), "Empty generics list")
+            syn::Error::new(bracketed.span(), "empty generics list")
         })? {
             syn::GenericArgument::Type(syn::Type::Path(p)) => {
                 let segment = p.path.segments.last().ok_or_else(|| {
-                    syn::Error::new(p.span(), "Empty generic path")
+                    syn::Error::new(p.span(), "empty generic path")
                 })?;
                 Ok(if segment.ident.to_string().as_str() == "c_char" {
                     Self::StringPointer
@@ -209,11 +210,11 @@ impl DartType {
             | syn::GenericArgument::AssocConst(_)
             | syn::GenericArgument::Constraint(_) => Err(syn::Error::new(
                 bracketed.span(),
-                "Unsupported generic argument",
+                "unsupported generic argument",
             )),
             _ => Err(syn::Error::new(
                 bracketed.span(),
-                "Unsupported unknown generic argument",
+                "unsupported unknown generic argument",
             )),
         }
     }
@@ -255,7 +256,7 @@ impl TryFrom<syn::Type> for DartType {
                 } else {
                     return Err(syn::Error::new(
                         value.span(),
-                        "Unsupported type",
+                        "unsupported type",
                     ));
                 }
             }
@@ -272,9 +273,9 @@ impl TryFrom<syn::Type> for DartType {
             | syn::Type::Slice(_)
             | syn::Type::TraitObject(_)
             | syn::Type::Verbatim(_) => {
-                return Err(syn::Error::new(value.span(), "Unsupported type"));
+                return Err(syn::Error::new(value.span(), "unsupported type"));
             }
-            _ => return Err(syn::Error::new(value.span(), "Unknown type")),
+            _ => return Err(syn::Error::new(value.span(), "unknown type")),
         })
     }
 }
@@ -335,7 +336,7 @@ pub(crate) struct FnRegistrationBuilder {
     /// Name of the registering function.
     pub(crate) name: syn::Ident,
 
-    /// [`syn::Ident`] of the extern function that saves error in its slot.
+    /// [`syn::Ident`] of the extern function that saves an error in its slot.
     pub(crate) error_setter_ident: syn::Ident,
 }
 
@@ -388,7 +389,7 @@ impl DartCodegen {
         self.generate_args(&mut out)?;
         writeln!(out, "}} ) {{")?;
 
-        // Save provided Dart functions. E.g.:
+        // Save the provided Dart functions, e.g.:
         //
         // _iceConnectionState = iceConnectionState;
         // _onConnectionStateChange = onConnectionStateChange;
@@ -467,8 +468,8 @@ impl DartCodegen {
         Ok(())
     }
 
-    /// Generates variables that stores Dart functions that will be called
-    /// by Rust side.
+    /// Generates variables storing Dart functions that will be called by Rust
+    /// side.
     ///
     /// # Example of generated code
     ///
@@ -499,8 +500,8 @@ impl DartCodegen {
         Ok(())
     }
 
-    /// Generates variables that store Dart bindings to Rust functions that
-    /// save execution errors.
+    /// Generates variables storing Dart bindings to Rust functions that save
+    /// execution errors.
     ///
     /// # Example of generated code
     ///

--- a/flutter/example/pubspec.lock
+++ b/flutter/example/pubspec.lock
@@ -286,18 +286,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -334,10 +334,10 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.8.0"
   medea_flutter_webrtc:
     dependency: "direct main"
     description:
@@ -357,10 +357,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -397,10 +397,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.4"
   pool:
     dependency: transitive
     description:
@@ -546,10 +546,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.0"
   tuple:
     dependency: transitive
     description:
@@ -586,10 +586,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.2.1"
   watcher:
     dependency: transitive
     description:

--- a/flutter/example/pubspec.lock
+++ b/flutter/example/pubspec.lock
@@ -286,18 +286,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -334,10 +334,10 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   medea_flutter_webrtc:
     dependency: "direct main"
     description:
@@ -357,10 +357,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   mime:
     dependency: transitive
     description:
@@ -397,10 +397,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
+      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.4"
+    version: "3.1.5"
   pool:
     dependency: transitive
     description:
@@ -546,10 +546,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   tuple:
     dependency: transitive
     description:
@@ -586,10 +586,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.4"
   watcher:
     dependency: transitive
     description:

--- a/flutter/lib/src/native/ffi/callback.dart
+++ b/flutter/lib/src/native/ffi/callback.dart
@@ -21,8 +21,8 @@ final _callbackTwoArgCall =
 void registerFunctions(DynamicLibrary dl) {
   bridge.registerFunction(
     dl,
-    callProxy: Pointer.fromFunction(_callProxy),
-    callTwoArgProxy: Pointer.fromFunction(_callTwoArgProxy),
+    callProxy: _callProxy,
+    callTwoArgProxy: _callTwoArgProxy,
   );
 }
 

--- a/flutter/lib/src/native/ffi/callback.g.dart
+++ b/flutter/lib/src/native/ffi/callback.g.dart
@@ -4,14 +4,60 @@ import 'package:ffi/ffi.dart';
 
 import 'package:medea_jason/src/native/ffi/foreign_value.dart';
 
+typedef _ErrorSetterFnC = Void Function(Handle);
+typedef _ErrorSetterFnDart = void Function(Object);
+
+Object Function(Pointer)? _callTwoArgProxy;
+Object Function(Pointer)? _callProxy;
+
+_ErrorSetterFnDart? _callback__call_two_arg_proxy__set_error;
+_ErrorSetterFnDart? _callback__call_proxy__set_error;
+
 void registerFunction(
   DynamicLibrary dl, {
-  required Pointer<NativeFunction<Handle Function(Pointer)>> callTwoArgProxy,
-  required Pointer<NativeFunction<Handle Function(Pointer)>> callProxy,
+  required Object Function(Pointer) callTwoArgProxy,
+  required Object Function(Pointer) callProxy,
 }) {
+  _callTwoArgProxy = callTwoArgProxy;
+  _callProxy = callProxy;
+
+  _callback__call_two_arg_proxy__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'callback__call_two_arg_proxy__set_error');
+  _callback__call_proxy__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'callback__call_proxy__set_error');
+
+  Pointer<NativeFunction<Handle Function(Pointer)>> callTwoArgProxy_native =
+      Pointer.fromFunction(
+    _callTwoArgProxyProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Pointer)>> callProxy_native =
+      Pointer.fromFunction(
+    _callProxyProxy,
+  );
+
   dl.lookupFunction<Void Function(Pointer, Pointer),
       void Function(Pointer, Pointer)>('register_callback')(
-    callTwoArgProxy,
-    callProxy,
+    callTwoArgProxy_native,
+    callProxy_native,
   );
+}
+
+Object _callTwoArgProxyProxy(Pointer a) {
+  try {
+    return _callTwoArgProxy!(a);
+  } catch (e) {
+    _callback__call_two_arg_proxy__set_error!(e);
+    return 0;
+  }
+}
+
+Object _callProxyProxy(Pointer a) {
+  try {
+    return _callProxy!(a);
+  } catch (e) {
+    _callback__call_proxy__set_error!(e);
+    return 0;
+  }
 }

--- a/flutter/lib/src/native/ffi/callback.g.dart
+++ b/flutter/lib/src/native/ffi/callback.g.dart
@@ -44,18 +44,18 @@ void registerFunction(
   );
 }
 
-Object _callTwoArgProxyProxy(Pointer a) {
+Object _callTwoArgProxyProxy(Pointer arg0) {
   try {
-    return _callTwoArgProxy!(a);
+    return _callTwoArgProxy!(arg0);
   } catch (e) {
     _callback__call_two_arg_proxy__set_error!(e);
     return 0;
   }
 }
 
-Object _callProxyProxy(Pointer a) {
+Object _callProxyProxy(Pointer arg0) {
   try {
-    return _callProxy!(a);
+    return _callProxy!(arg0);
   } catch (e) {
     _callback__call_proxy__set_error!(e);
     return 0;

--- a/flutter/lib/src/native/ffi/completer.dart
+++ b/flutter/lib/src/native/ffi/completer.dart
@@ -9,27 +9,27 @@ import 'foreign_value.dart';
 void registerFunctions(DynamicLibrary dl) {
   bridge.registerFunction(
     dl,
-    init: Pointer.fromFunction(_new),
-    future: Pointer.fromFunction(_future),
-    complete: Pointer.fromFunction(_complete),
-    completeError: Pointer.fromFunction(_completeError),
-    delayed: Pointer.fromFunction(_delayed),
+    init: _new,
+    future: _future,
+    complete: _complete,
+    completeError: _completeError,
+    delayed: _delayed,
   );
 }
 
 /// Returns closure returning a [Future.delayed] with the provided amount of
 /// milliseconds.
-Object _delayed(int delayMs) {
+Future Function() _delayed(int delayMs) {
   return () => Future.delayed(Duration(milliseconds: delayMs));
 }
 
 /// Returns a new [Completer].
-Object _new() {
+Completer _new() {
   return Completer();
 }
 
 /// Returns a [Future] that is completed by the provided [Completer].
-Object _future(Object completer) {
+Future _future(Object completer) {
   completer as Completer;
   return completer.future;
 }

--- a/flutter/lib/src/native/ffi/completer.g.dart
+++ b/flutter/lib/src/native/ffi/completer.g.dart
@@ -4,24 +4,124 @@ import 'package:ffi/ffi.dart';
 
 import 'package:medea_jason/src/native/ffi/foreign_value.dart';
 
+typedef _ErrorSetterFnC = Void Function(Handle);
+typedef _ErrorSetterFnDart = void Function(Object);
+
+Object Function()? _init;
+void Function(Object, ForeignValue)? _complete;
+void Function(Object, Pointer<Handle>)? _completeError;
+Object Function(Object)? _future;
+Object Function(int)? _delayed;
+
+_ErrorSetterFnDart? _completer__init__set_error;
+_ErrorSetterFnDart? _completer__complete__set_error;
+_ErrorSetterFnDart? _completer__complete_error__set_error;
+_ErrorSetterFnDart? _completer__future__set_error;
+_ErrorSetterFnDart? _completer__delayed__set_error;
+
 void registerFunction(
   DynamicLibrary dl, {
-  required Pointer<NativeFunction<Handle Function()>> init,
-  required Pointer<NativeFunction<Void Function(Handle, ForeignValue)>>
-      complete,
-  required Pointer<NativeFunction<Void Function(Handle, Pointer<Handle>)>>
-      completeError,
-  required Pointer<NativeFunction<Handle Function(Handle)>> future,
-  required Pointer<NativeFunction<Handle Function(Int32)>> delayed,
+  required Object Function() init,
+  required void Function(Object, ForeignValue) complete,
+  required void Function(Object, Pointer<Handle>) completeError,
+  required Object Function(Object) future,
+  required Object Function(int) delayed,
 }) {
+  _init = init;
+  _complete = complete;
+  _completeError = completeError;
+  _future = future;
+  _delayed = delayed;
+
+  _completer__init__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'completer__init__set_error');
+  _completer__complete__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'completer__complete__set_error');
+  _completer__complete_error__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'completer__complete_error__set_error');
+  _completer__future__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'completer__future__set_error');
+  _completer__delayed__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'completer__delayed__set_error');
+
+  Pointer<NativeFunction<Handle Function()>> init_native = Pointer.fromFunction(
+    _initProxy,
+  );
+  Pointer<NativeFunction<Void Function(Handle, ForeignValue)>> complete_native =
+      Pointer.fromFunction(
+    _completeProxy,
+  );
+  Pointer<NativeFunction<Void Function(Handle, Pointer<Handle>)>>
+      completeError_native = Pointer.fromFunction(
+    _completeErrorProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Handle)>> future_native =
+      Pointer.fromFunction(
+    _futureProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Int32)>> delayed_native =
+      Pointer.fromFunction(
+    _delayedProxy,
+  );
+
   dl.lookupFunction<
       Void Function(Pointer, Pointer, Pointer, Pointer, Pointer),
       void Function(
           Pointer, Pointer, Pointer, Pointer, Pointer)>('register_completer')(
-    init,
-    complete,
-    completeError,
-    future,
-    delayed,
+    init_native,
+    complete_native,
+    completeError_native,
+    future_native,
+    delayed_native,
   );
+}
+
+Object _initProxy() {
+  try {
+    return _init!();
+  } catch (e) {
+    _completer__init__set_error!(e);
+    return 0;
+  }
+}
+
+void _completeProxy(Object a, ForeignValue b) {
+  try {
+    return _complete!(a, b);
+  } catch (e) {
+    _completer__complete__set_error!(e);
+    return;
+  }
+}
+
+void _completeErrorProxy(Object a, Pointer<Handle> b) {
+  try {
+    return _completeError!(a, b);
+  } catch (e) {
+    _completer__complete_error__set_error!(e);
+    return;
+  }
+}
+
+Object _futureProxy(Object a) {
+  try {
+    return _future!(a);
+  } catch (e) {
+    _completer__future__set_error!(e);
+    return 0;
+  }
+}
+
+Object _delayedProxy(int a) {
+  try {
+    return _delayed!(a);
+  } catch (e) {
+    _completer__delayed__set_error!(e);
+    return 0;
+  }
 }

--- a/flutter/lib/src/native/ffi/completer.g.dart
+++ b/flutter/lib/src/native/ffi/completer.g.dart
@@ -90,36 +90,36 @@ Object _initProxy() {
   }
 }
 
-void _completeProxy(Object a, ForeignValue b) {
+void _completeProxy(Object arg0, ForeignValue arg1) {
   try {
-    return _complete!(a, b);
+    return _complete!(arg0, arg1);
   } catch (e) {
     _completer__complete__set_error!(e);
     return;
   }
 }
 
-void _completeErrorProxy(Object a, Pointer<Handle> b) {
+void _completeErrorProxy(Object arg0, Pointer<Handle> arg1) {
   try {
-    return _completeError!(a, b);
+    return _completeError!(arg0, arg1);
   } catch (e) {
     _completer__complete_error__set_error!(e);
     return;
   }
 }
 
-Object _futureProxy(Object a) {
+Object _futureProxy(Object arg0) {
   try {
-    return _future!(a);
+    return _future!(arg0);
   } catch (e) {
     _completer__future__set_error!(e);
     return 0;
   }
 }
 
-Object _delayedProxy(int a) {
+Object _delayedProxy(int arg0) {
   try {
-    return _delayed!(a);
+    return _delayed!(arg0);
   } catch (e) {
     _completer__delayed__set_error!(e);
     return 0;

--- a/flutter/lib/src/native/ffi/exception.dart
+++ b/flutter/lib/src/native/ffi/exception.dart
@@ -21,7 +21,7 @@ void registerFunctions(DynamicLibrary dl) {
       newMediaSettingsUpdateException: _newMediaSettingsUpdateException,
       newInvalidOutputAudioDeviceIdException:
           _newInvalidOutputAudioDeviceIdException,
-      throwPanicException: _throwPanicException,
+      newPanicException: _newPanicException,
       newMicVolumeException: _newMicVolumeException);
 }
 
@@ -105,13 +105,9 @@ NativeMediaSettingsUpdateException _newMediaSettingsUpdateException(
       message.nativeStringToDartString(), unboxDartHandle(cause), rolledBack);
 }
 
-/// Throws a new [NativePanicException]. TODO: asdasdasdasd
-NativePanicException _throwPanicException() {
-  try {
-    throw NativePanicException();
-  } on NativePanicException catch (e) {
-    return e;
-  }
+/// Creates a new [NativePanicException].
+NativePanicException _newPanicException() {
+  return NativePanicException();
 }
 
 /// Exception thrown whenever Rust side panics.

--- a/flutter/lib/src/native/ffi/exception.dart
+++ b/flutter/lib/src/native/ffi/exception.dart
@@ -11,22 +11,18 @@ import 'native_string.dart';
 /// Registers functions allowing Rust to create Dart [Exception]s and [Error]s.
 void registerFunctions(DynamicLibrary dl) {
   bridge.registerFunction(dl,
-      newStateError: Pointer.fromFunction(_newStateError),
-      newFormatException: Pointer.fromFunction(_newFormatException),
-      newLocalMediaInitException:
-          Pointer.fromFunction(_newLocalMediaInitException),
-      newEnumerateDevicesException:
-          Pointer.fromFunction(_newEnumerateDevicesException),
-      newRpcClientException: Pointer.fromFunction(_newRpcClientException),
-      newMediaStateTransitionException:
-          Pointer.fromFunction(_newMediaStateTransitionException),
-      newInternalException: Pointer.fromFunction(_newInternalException),
-      newMediaSettingsUpdateException:
-          Pointer.fromFunction(_newMediaSettingsUpdateException),
+      newStateError: _newStateError,
+      newFormatException: _newFormatException,
+      newLocalMediaInitException: _newLocalMediaInitException,
+      newEnumerateDevicesException: _newEnumerateDevicesException,
+      newRpcClientException: _newRpcClientException,
+      newMediaStateTransitionException: _newMediaStateTransitionException,
+      newInternalException: _newInternalException,
+      newMediaSettingsUpdateException: _newMediaSettingsUpdateException,
       newInvalidOutputAudioDeviceIdException:
-          Pointer.fromFunction(_newInvalidOutputAudioDeviceIdException),
-      throwPanicException: Pointer.fromFunction(_throwPanicException),
-      newMicVolumeException: Pointer.fromFunction(_newMicVolumeException));
+          _newInvalidOutputAudioDeviceIdException,
+      throwPanicException: _throwPanicException,
+      newMicVolumeException: _newMicVolumeException);
 }
 
 /// Creates a new [StateError] with the provided [message].
@@ -85,7 +81,7 @@ Object _newRpcClientException(int kind, Pointer<Utf8> message,
 
 /// Creates a new [NativeMediaStateTransitionException] with the provided error
 /// [message] and [stacktrace].
-Object _newMediaStateTransitionException(
+NativeMediaStateTransitionException _newMediaStateTransitionException(
     Pointer<Utf8> message, Pointer<Utf8> stacktrace, int kind) {
   return NativeMediaStateTransitionException(
       message.nativeStringToDartString(),
@@ -95,7 +91,7 @@ Object _newMediaStateTransitionException(
 
 /// Creates a new [InternalException] with the provided error [message], error
 /// [cause] and [stacktrace].
-Object _newInternalException(
+NativeInternalException _newInternalException(
     Pointer<Utf8> message, ForeignValue cause, Pointer<Utf8> stacktrace) {
   return NativeInternalException(message.nativeStringToDartString(),
       cause.toDart(), stacktrace.nativeStringToDartString());
@@ -103,14 +99,14 @@ Object _newInternalException(
 
 /// Creates a new [NativeMediaSettingsUpdateException] with the provided error
 /// [message], error [cause] and [rolledBack] property.
-Object _newMediaSettingsUpdateException(
+NativeMediaSettingsUpdateException _newMediaSettingsUpdateException(
     Pointer<Utf8> message, Pointer<Handle> cause, bool rolledBack) {
   return NativeMediaSettingsUpdateException(
       message.nativeStringToDartString(), unboxDartHandle(cause), rolledBack);
 }
 
-/// Throws a new [NativePanicException].
-Object _throwPanicException() {
+/// Throws a new [NativePanicException]. TODO: asdasdasdasd
+String _throwPanicException() {
   throw NativePanicException();
 }
 

--- a/flutter/lib/src/native/ffi/exception.dart
+++ b/flutter/lib/src/native/ffi/exception.dart
@@ -106,8 +106,12 @@ NativeMediaSettingsUpdateException _newMediaSettingsUpdateException(
 }
 
 /// Throws a new [NativePanicException]. TODO: asdasdasdasd
-String _throwPanicException() {
-  throw NativePanicException();
+NativePanicException _throwPanicException() {
+  try {
+    throw NativePanicException();
+  } on NativePanicException catch (e) {
+    return e;
+  }
 }
 
 /// Exception thrown whenever Rust side panics.

--- a/flutter/lib/src/native/ffi/exception.g.dart
+++ b/flutter/lib/src/native/ffi/exception.g.dart
@@ -178,18 +178,18 @@ void registerFunction(
   );
 }
 
-Object _newStateErrorProxy(Pointer<Utf8> a) {
+Object _newStateErrorProxy(Pointer<Utf8> arg0) {
   try {
-    return _newStateError!(a);
+    return _newStateError!(arg0);
   } catch (e) {
     _exception__new_state_error__set_error!(e);
     return 0;
   }
 }
 
-Object _newFormatExceptionProxy(Pointer<Utf8> a) {
+Object _newFormatExceptionProxy(Pointer<Utf8> arg0) {
   try {
-    return _newFormatException!(a);
+    return _newFormatException!(arg0);
   } catch (e) {
     _exception__new_format_exception__set_error!(e);
     return 0;
@@ -197,18 +197,19 @@ Object _newFormatExceptionProxy(Pointer<Utf8> a) {
 }
 
 Object _newLocalMediaInitExceptionProxy(
-    int a, Pointer<Utf8> b, ForeignValue c, Pointer<Utf8> d) {
+    int arg0, Pointer<Utf8> arg1, ForeignValue arg2, Pointer<Utf8> arg3) {
   try {
-    return _newLocalMediaInitException!(a, b, c, d);
+    return _newLocalMediaInitException!(arg0, arg1, arg2, arg3);
   } catch (e) {
     _exception__new_local_media_init_exception__set_error!(e);
     return 0;
   }
 }
 
-Object _newEnumerateDevicesExceptionProxy(Pointer<Handle> a, Pointer<Utf8> b) {
+Object _newEnumerateDevicesExceptionProxy(
+    Pointer<Handle> arg0, Pointer<Utf8> arg1) {
   try {
-    return _newEnumerateDevicesException!(a, b);
+    return _newEnumerateDevicesException!(arg0, arg1);
   } catch (e) {
     _exception__new_enumerate_devices_exception__set_error!(e);
     return 0;
@@ -216,9 +217,9 @@ Object _newEnumerateDevicesExceptionProxy(Pointer<Handle> a, Pointer<Utf8> b) {
 }
 
 Object _newRpcClientExceptionProxy(
-    int a, Pointer<Utf8> b, ForeignValue c, Pointer<Utf8> d) {
+    int arg0, Pointer<Utf8> arg1, ForeignValue arg2, Pointer<Utf8> arg3) {
   try {
-    return _newRpcClientException!(a, b, c, d);
+    return _newRpcClientException!(arg0, arg1, arg2, arg3);
   } catch (e) {
     _exception__new_rpc_client_exception__set_error!(e);
     return 0;
@@ -226,9 +227,9 @@ Object _newRpcClientExceptionProxy(
 }
 
 Object _newMediaStateTransitionExceptionProxy(
-    Pointer<Utf8> a, Pointer<Utf8> b, int c) {
+    Pointer<Utf8> arg0, Pointer<Utf8> arg1, int arg2) {
   try {
-    return _newMediaStateTransitionException!(a, b, c);
+    return _newMediaStateTransitionException!(arg0, arg1, arg2);
   } catch (e) {
     _exception__new_media_state_transition_exception__set_error!(e);
     return 0;
@@ -236,9 +237,9 @@ Object _newMediaStateTransitionExceptionProxy(
 }
 
 Object _newInternalExceptionProxy(
-    Pointer<Utf8> a, ForeignValue b, Pointer<Utf8> c) {
+    Pointer<Utf8> arg0, ForeignValue arg1, Pointer<Utf8> arg2) {
   try {
-    return _newInternalException!(a, b, c);
+    return _newInternalException!(arg0, arg1, arg2);
   } catch (e) {
     _exception__new_internal_exception__set_error!(e);
     return 0;
@@ -246,27 +247,27 @@ Object _newInternalExceptionProxy(
 }
 
 Object _newMediaSettingsUpdateExceptionProxy(
-    Pointer<Utf8> a, Pointer<Handle> b, bool c) {
+    Pointer<Utf8> arg0, Pointer<Handle> arg1, bool arg2) {
   try {
-    return _newMediaSettingsUpdateException!(a, b, c);
+    return _newMediaSettingsUpdateException!(arg0, arg1, arg2);
   } catch (e) {
     _exception__new_media_settings_update_exception__set_error!(e);
     return 0;
   }
 }
 
-Object _newInvalidOutputAudioDeviceIdExceptionProxy(Pointer<Utf8> a) {
+Object _newInvalidOutputAudioDeviceIdExceptionProxy(Pointer<Utf8> arg0) {
   try {
-    return _newInvalidOutputAudioDeviceIdException!(a);
+    return _newInvalidOutputAudioDeviceIdException!(arg0);
   } catch (e) {
     _exception__new_invalid_output_audio_device_id_exception__set_error!(e);
     return 0;
   }
 }
 
-Object _newMicVolumeExceptionProxy(Pointer<Handle> a, Pointer<Utf8> b) {
+Object _newMicVolumeExceptionProxy(Pointer<Handle> arg0, Pointer<Utf8> arg1) {
   try {
-    return _newMicVolumeException!(a, b);
+    return _newMicVolumeException!(arg0, arg1);
   } catch (e) {
     _exception__new_mic_volume_exception__set_error!(e);
     return 0;

--- a/flutter/lib/src/native/ffi/exception.g.dart
+++ b/flutter/lib/src/native/ffi/exception.g.dart
@@ -22,7 +22,7 @@ Object Function(Pointer<Utf8>, Pointer<Handle>, bool)?
     _newMediaSettingsUpdateException;
 Object Function(Pointer<Utf8>)? _newInvalidOutputAudioDeviceIdException;
 Object Function(Pointer<Handle>, Pointer<Utf8>)? _newMicVolumeException;
-Object Function()? _throwPanicException;
+Object Function()? _newPanicException;
 
 _ErrorSetterFnDart? _exception__new_state_error__set_error;
 _ErrorSetterFnDart? _exception__new_format_exception__set_error;
@@ -35,7 +35,7 @@ _ErrorSetterFnDart? _exception__new_media_settings_update_exception__set_error;
 _ErrorSetterFnDart?
     _exception__new_invalid_output_audio_device_id_exception__set_error;
 _ErrorSetterFnDart? _exception__new_mic_volume_exception__set_error;
-_ErrorSetterFnDart? _exception__throw_panic_exception__set_error;
+_ErrorSetterFnDart? _exception__new_panic_exception__set_error;
 
 void registerFunction(
   DynamicLibrary dl, {
@@ -57,7 +57,7 @@ void registerFunction(
       newInvalidOutputAudioDeviceIdException,
   required Object Function(Pointer<Handle>, Pointer<Utf8>)
       newMicVolumeException,
-  required Object Function() throwPanicException,
+  required Object Function() newPanicException,
 }) {
   _newStateError = newStateError;
   _newFormatException = newFormatException;
@@ -70,7 +70,7 @@ void registerFunction(
   _newInvalidOutputAudioDeviceIdException =
       newInvalidOutputAudioDeviceIdException;
   _newMicVolumeException = newMicVolumeException;
-  _throwPanicException = throwPanicException;
+  _newPanicException = newPanicException;
 
   _exception__new_state_error__set_error =
       dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
@@ -102,9 +102,9 @@ void registerFunction(
   _exception__new_mic_volume_exception__set_error =
       dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
           'exception__new_mic_volume_exception__set_error');
-  _exception__throw_panic_exception__set_error =
+  _exception__new_panic_exception__set_error =
       dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
-          'exception__throw_panic_exception__set_error');
+          'exception__new_panic_exception__set_error');
 
   Pointer<NativeFunction<Handle Function(Pointer<Utf8>)>> newStateError_native =
       Pointer.fromFunction(
@@ -154,9 +154,9 @@ void registerFunction(
       newMicVolumeException_native = Pointer.fromFunction(
     _newMicVolumeExceptionProxy,
   );
-  Pointer<NativeFunction<Handle Function()>> throwPanicException_native =
+  Pointer<NativeFunction<Handle Function()>> newPanicException_native =
       Pointer.fromFunction(
-    _throwPanicExceptionProxy,
+    _newPanicExceptionProxy,
   );
 
   dl.lookupFunction<
@@ -174,7 +174,7 @@ void registerFunction(
     newMediaSettingsUpdateException_native,
     newInvalidOutputAudioDeviceIdException_native,
     newMicVolumeException_native,
-    throwPanicException_native,
+    newPanicException_native,
   );
 }
 
@@ -274,11 +274,11 @@ Object _newMicVolumeExceptionProxy(Pointer<Handle> arg0, Pointer<Utf8> arg1) {
   }
 }
 
-Object _throwPanicExceptionProxy() {
+Object _newPanicExceptionProxy() {
   try {
-    return _throwPanicException!();
+    return _newPanicException!();
   } catch (e) {
-    _exception__throw_panic_exception__set_error!(e);
+    _exception__new_panic_exception__set_error!(e);
     return 0;
   }
 }

--- a/flutter/lib/src/native/ffi/exception.g.dart
+++ b/flutter/lib/src/native/ffi/exception.g.dart
@@ -4,57 +4,280 @@ import 'package:ffi/ffi.dart';
 
 import 'package:medea_jason/src/native/ffi/foreign_value.dart';
 
+typedef _ErrorSetterFnC = Void Function(Handle);
+typedef _ErrorSetterFnDart = void Function(Object);
+
+Object Function(Pointer<Utf8>)? _newStateError;
+Object Function(Pointer<Utf8>)? _newFormatException;
+Object Function(int, Pointer<Utf8>, ForeignValue, Pointer<Utf8>)?
+    _newLocalMediaInitException;
+Object Function(Pointer<Handle>, Pointer<Utf8>)? _newEnumerateDevicesException;
+Object Function(int, Pointer<Utf8>, ForeignValue, Pointer<Utf8>)?
+    _newRpcClientException;
+Object Function(Pointer<Utf8>, Pointer<Utf8>, int)?
+    _newMediaStateTransitionException;
+Object Function(Pointer<Utf8>, ForeignValue, Pointer<Utf8>)?
+    _newInternalException;
+Object Function(Pointer<Utf8>, Pointer<Handle>, bool)?
+    _newMediaSettingsUpdateException;
+Object Function(Pointer<Utf8>)? _newInvalidOutputAudioDeviceIdException;
+Object Function(Pointer<Handle>, Pointer<Utf8>)? _newMicVolumeException;
+Object Function()? _throwPanicException;
+
+_ErrorSetterFnDart? _exception__new_state_error__set_error;
+_ErrorSetterFnDart? _exception__new_format_exception__set_error;
+_ErrorSetterFnDart? _exception__new_local_media_init_exception__set_error;
+_ErrorSetterFnDart? _exception__new_enumerate_devices_exception__set_error;
+_ErrorSetterFnDart? _exception__new_rpc_client_exception__set_error;
+_ErrorSetterFnDart? _exception__new_media_state_transition_exception__set_error;
+_ErrorSetterFnDart? _exception__new_internal_exception__set_error;
+_ErrorSetterFnDart? _exception__new_media_settings_update_exception__set_error;
+_ErrorSetterFnDart?
+    _exception__new_invalid_output_audio_device_id_exception__set_error;
+_ErrorSetterFnDart? _exception__new_mic_volume_exception__set_error;
+_ErrorSetterFnDart? _exception__throw_panic_exception__set_error;
+
 void registerFunction(
   DynamicLibrary dl, {
-  required Pointer<NativeFunction<Handle Function(Pointer<Utf8>)>>
-      newStateError,
-  required Pointer<NativeFunction<Handle Function(Pointer<Utf8>)>>
-      newFormatException,
-  required Pointer<
-          NativeFunction<
-              Handle Function(
-                  Int64, Pointer<Utf8>, ForeignValue, Pointer<Utf8>)>>
+  required Object Function(Pointer<Utf8>) newStateError,
+  required Object Function(Pointer<Utf8>) newFormatException,
+  required Object Function(int, Pointer<Utf8>, ForeignValue, Pointer<Utf8>)
       newLocalMediaInitException,
-  required Pointer<
-          NativeFunction<Handle Function(Pointer<Handle>, Pointer<Utf8>)>>
+  required Object Function(Pointer<Handle>, Pointer<Utf8>)
       newEnumerateDevicesException,
-  required Pointer<
+  required Object Function(int, Pointer<Utf8>, ForeignValue, Pointer<Utf8>)
+      newRpcClientException,
+  required Object Function(Pointer<Utf8>, Pointer<Utf8>, int)
+      newMediaStateTransitionException,
+  required Object Function(Pointer<Utf8>, ForeignValue, Pointer<Utf8>)
+      newInternalException,
+  required Object Function(Pointer<Utf8>, Pointer<Handle>, bool)
+      newMediaSettingsUpdateException,
+  required Object Function(Pointer<Utf8>)
+      newInvalidOutputAudioDeviceIdException,
+  required Object Function(Pointer<Handle>, Pointer<Utf8>)
+      newMicVolumeException,
+  required Object Function() throwPanicException,
+}) {
+  _newStateError = newStateError;
+  _newFormatException = newFormatException;
+  _newLocalMediaInitException = newLocalMediaInitException;
+  _newEnumerateDevicesException = newEnumerateDevicesException;
+  _newRpcClientException = newRpcClientException;
+  _newMediaStateTransitionException = newMediaStateTransitionException;
+  _newInternalException = newInternalException;
+  _newMediaSettingsUpdateException = newMediaSettingsUpdateException;
+  _newInvalidOutputAudioDeviceIdException =
+      newInvalidOutputAudioDeviceIdException;
+  _newMicVolumeException = newMicVolumeException;
+  _throwPanicException = throwPanicException;
+
+  _exception__new_state_error__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'exception__new_state_error__set_error');
+  _exception__new_format_exception__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'exception__new_format_exception__set_error');
+  _exception__new_local_media_init_exception__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'exception__new_local_media_init_exception__set_error');
+  _exception__new_enumerate_devices_exception__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'exception__new_enumerate_devices_exception__set_error');
+  _exception__new_rpc_client_exception__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'exception__new_rpc_client_exception__set_error');
+  _exception__new_media_state_transition_exception__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'exception__new_media_state_transition_exception__set_error');
+  _exception__new_internal_exception__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'exception__new_internal_exception__set_error');
+  _exception__new_media_settings_update_exception__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'exception__new_media_settings_update_exception__set_error');
+  _exception__new_invalid_output_audio_device_id_exception__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'exception__new_invalid_output_audio_device_id_exception__set_error');
+  _exception__new_mic_volume_exception__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'exception__new_mic_volume_exception__set_error');
+  _exception__throw_panic_exception__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'exception__throw_panic_exception__set_error');
+
+  Pointer<NativeFunction<Handle Function(Pointer<Utf8>)>> newStateError_native =
+      Pointer.fromFunction(
+    _newStateErrorProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Pointer<Utf8>)>>
+      newFormatException_native = Pointer.fromFunction(
+    _newFormatExceptionProxy,
+  );
+  Pointer<
           NativeFunction<
               Handle Function(
                   Int64, Pointer<Utf8>, ForeignValue, Pointer<Utf8>)>>
-      newRpcClientException,
-  required Pointer<
-          NativeFunction<Handle Function(Pointer<Utf8>, Pointer<Utf8>, Int64)>>
-      newMediaStateTransitionException,
-  required Pointer<
+      newLocalMediaInitException_native = Pointer.fromFunction(
+    _newLocalMediaInitExceptionProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Pointer<Handle>, Pointer<Utf8>)>>
+      newEnumerateDevicesException_native = Pointer.fromFunction(
+    _newEnumerateDevicesExceptionProxy,
+  );
+  Pointer<
+          NativeFunction<
+              Handle Function(
+                  Int64, Pointer<Utf8>, ForeignValue, Pointer<Utf8>)>>
+      newRpcClientException_native = Pointer.fromFunction(
+    _newRpcClientExceptionProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Pointer<Utf8>, Pointer<Utf8>, Int64)>>
+      newMediaStateTransitionException_native = Pointer.fromFunction(
+    _newMediaStateTransitionExceptionProxy,
+  );
+  Pointer<
           NativeFunction<
               Handle Function(Pointer<Utf8>, ForeignValue, Pointer<Utf8>)>>
-      newInternalException,
-  required Pointer<
-          NativeFunction<Handle Function(Pointer<Utf8>, Pointer<Handle>, Bool)>>
-      newMediaSettingsUpdateException,
-  required Pointer<NativeFunction<Handle Function(Pointer<Utf8>)>>
-      newInvalidOutputAudioDeviceIdException,
-  required Pointer<
-          NativeFunction<Handle Function(Pointer<Handle>, Pointer<Utf8>)>>
-      newMicVolumeException,
-  required Pointer<NativeFunction<Handle Function()>> throwPanicException,
-}) {
+      newInternalException_native = Pointer.fromFunction(
+    _newInternalExceptionProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Pointer<Utf8>, Pointer<Handle>, Bool)>>
+      newMediaSettingsUpdateException_native = Pointer.fromFunction(
+    _newMediaSettingsUpdateExceptionProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Pointer<Utf8>)>>
+      newInvalidOutputAudioDeviceIdException_native = Pointer.fromFunction(
+    _newInvalidOutputAudioDeviceIdExceptionProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Pointer<Handle>, Pointer<Utf8>)>>
+      newMicVolumeException_native = Pointer.fromFunction(
+    _newMicVolumeExceptionProxy,
+  );
+  Pointer<NativeFunction<Handle Function()>> throwPanicException_native =
+      Pointer.fromFunction(
+    _throwPanicExceptionProxy,
+  );
+
   dl.lookupFunction<
       Void Function(Pointer, Pointer, Pointer, Pointer, Pointer, Pointer,
           Pointer, Pointer, Pointer, Pointer, Pointer),
       void Function(Pointer, Pointer, Pointer, Pointer, Pointer, Pointer,
           Pointer, Pointer, Pointer, Pointer, Pointer)>('register_exception')(
-    newStateError,
-    newFormatException,
-    newLocalMediaInitException,
-    newEnumerateDevicesException,
-    newRpcClientException,
-    newMediaStateTransitionException,
-    newInternalException,
-    newMediaSettingsUpdateException,
-    newInvalidOutputAudioDeviceIdException,
-    newMicVolumeException,
-    throwPanicException,
+    newStateError_native,
+    newFormatException_native,
+    newLocalMediaInitException_native,
+    newEnumerateDevicesException_native,
+    newRpcClientException_native,
+    newMediaStateTransitionException_native,
+    newInternalException_native,
+    newMediaSettingsUpdateException_native,
+    newInvalidOutputAudioDeviceIdException_native,
+    newMicVolumeException_native,
+    throwPanicException_native,
   );
+}
+
+Object _newStateErrorProxy(Pointer<Utf8> a) {
+  try {
+    return _newStateError!(a);
+  } catch (e) {
+    _exception__new_state_error__set_error!(e);
+    return 0;
+  }
+}
+
+Object _newFormatExceptionProxy(Pointer<Utf8> a) {
+  try {
+    return _newFormatException!(a);
+  } catch (e) {
+    _exception__new_format_exception__set_error!(e);
+    return 0;
+  }
+}
+
+Object _newLocalMediaInitExceptionProxy(
+    int a, Pointer<Utf8> b, ForeignValue c, Pointer<Utf8> d) {
+  try {
+    return _newLocalMediaInitException!(a, b, c, d);
+  } catch (e) {
+    _exception__new_local_media_init_exception__set_error!(e);
+    return 0;
+  }
+}
+
+Object _newEnumerateDevicesExceptionProxy(Pointer<Handle> a, Pointer<Utf8> b) {
+  try {
+    return _newEnumerateDevicesException!(a, b);
+  } catch (e) {
+    _exception__new_enumerate_devices_exception__set_error!(e);
+    return 0;
+  }
+}
+
+Object _newRpcClientExceptionProxy(
+    int a, Pointer<Utf8> b, ForeignValue c, Pointer<Utf8> d) {
+  try {
+    return _newRpcClientException!(a, b, c, d);
+  } catch (e) {
+    _exception__new_rpc_client_exception__set_error!(e);
+    return 0;
+  }
+}
+
+Object _newMediaStateTransitionExceptionProxy(
+    Pointer<Utf8> a, Pointer<Utf8> b, int c) {
+  try {
+    return _newMediaStateTransitionException!(a, b, c);
+  } catch (e) {
+    _exception__new_media_state_transition_exception__set_error!(e);
+    return 0;
+  }
+}
+
+Object _newInternalExceptionProxy(
+    Pointer<Utf8> a, ForeignValue b, Pointer<Utf8> c) {
+  try {
+    return _newInternalException!(a, b, c);
+  } catch (e) {
+    _exception__new_internal_exception__set_error!(e);
+    return 0;
+  }
+}
+
+Object _newMediaSettingsUpdateExceptionProxy(
+    Pointer<Utf8> a, Pointer<Handle> b, bool c) {
+  try {
+    return _newMediaSettingsUpdateException!(a, b, c);
+  } catch (e) {
+    _exception__new_media_settings_update_exception__set_error!(e);
+    return 0;
+  }
+}
+
+Object _newInvalidOutputAudioDeviceIdExceptionProxy(Pointer<Utf8> a) {
+  try {
+    return _newInvalidOutputAudioDeviceIdException!(a);
+  } catch (e) {
+    _exception__new_invalid_output_audio_device_id_exception__set_error!(e);
+    return 0;
+  }
+}
+
+Object _newMicVolumeExceptionProxy(Pointer<Handle> a, Pointer<Utf8> b) {
+  try {
+    return _newMicVolumeException!(a, b);
+  } catch (e) {
+    _exception__new_mic_volume_exception__set_error!(e);
+    return 0;
+  }
+}
+
+Object _throwPanicExceptionProxy() {
+  try {
+    return _throwPanicException!();
+  } catch (e) {
+    _exception__throw_panic_exception__set_error!(e);
+    return 0;
+  }
 }

--- a/flutter/lib/src/native/ffi/function.dart
+++ b/flutter/lib/src/native/ffi/function.dart
@@ -8,7 +8,7 @@ import 'function.g.dart' as bridge;
 void registerFunctions(DynamicLibrary dl) {
   bridge.registerFunction(
     dl,
-    caller: Pointer.fromFunction(_callFn),
+    caller: _callFn,
   );
 }
 

--- a/flutter/lib/src/native/ffi/function.g.dart
+++ b/flutter/lib/src/native/ffi/function.g.dart
@@ -4,12 +4,39 @@ import 'package:ffi/ffi.dart';
 
 import 'package:medea_jason/src/native/ffi/foreign_value.dart';
 
+typedef _ErrorSetterFnC = Void Function(Handle);
+typedef _ErrorSetterFnDart = void Function(Object);
+
+void Function(Object, ForeignValue)? _caller;
+
+_ErrorSetterFnDart? _function__caller__set_error;
+
 void registerFunction(
   DynamicLibrary dl, {
-  required Pointer<NativeFunction<Void Function(Handle, ForeignValue)>> caller,
+  required void Function(Object, ForeignValue) caller,
 }) {
+  _caller = caller;
+
+  _function__caller__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'function__caller__set_error');
+
+  Pointer<NativeFunction<Void Function(Handle, ForeignValue)>> caller_native =
+      Pointer.fromFunction(
+    _callerProxy,
+  );
+
   dl.lookupFunction<Void Function(Pointer), void Function(Pointer)>(
       'register_function')(
-    caller,
+    caller_native,
   );
+}
+
+void _callerProxy(Object a, ForeignValue b) {
+  try {
+    return _caller!(a, b);
+  } catch (e) {
+    _function__caller__set_error!(e);
+    return;
+  }
 }

--- a/flutter/lib/src/native/ffi/function.g.dart
+++ b/flutter/lib/src/native/ffi/function.g.dart
@@ -32,9 +32,9 @@ void registerFunction(
   );
 }
 
-void _callerProxy(Object a, ForeignValue b) {
+void _callerProxy(Object arg0, ForeignValue arg1) {
   try {
-    return _caller!(a, b);
+    return _caller!(arg0, arg1);
   } catch (e) {
     _function__caller__set_error!(e);
     return;

--- a/flutter/lib/src/native/ffi/future.dart
+++ b/flutter/lib/src/native/ffi/future.dart
@@ -20,7 +20,7 @@ final _futureResolveErr =
 void registerFunctions(DynamicLibrary dl) {
   bridge.registerFunction(
     dl,
-    completeProxy: Pointer.fromFunction(_completeProxy),
+    completeProxy: _completeProxy,
   );
 }
 

--- a/flutter/lib/src/native/ffi/future.g.dart
+++ b/flutter/lib/src/native/ffi/future.g.dart
@@ -4,13 +4,39 @@ import 'package:ffi/ffi.dart';
 
 import 'package:medea_jason/src/native/ffi/foreign_value.dart';
 
+typedef _ErrorSetterFnC = Void Function(Handle);
+typedef _ErrorSetterFnDart = void Function(Object);
+
+void Function(Object, Pointer)? _completeProxy;
+
+_ErrorSetterFnDart? _future_from_dart__complete_proxy__set_error;
+
 void registerFunction(
   DynamicLibrary dl, {
-  required Pointer<NativeFunction<Void Function(Handle, Pointer)>>
-      completeProxy,
+  required void Function(Object, Pointer) completeProxy,
 }) {
+  _completeProxy = completeProxy;
+
+  _future_from_dart__complete_proxy__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'future_from_dart__complete_proxy__set_error');
+
+  Pointer<NativeFunction<Void Function(Handle, Pointer)>> completeProxy_native =
+      Pointer.fromFunction(
+    _completeProxyProxy,
+  );
+
   dl.lookupFunction<Void Function(Pointer), void Function(Pointer)>(
       'register_future_from_dart')(
-    completeProxy,
+    completeProxy_native,
   );
+}
+
+void _completeProxyProxy(Object a, Pointer b) {
+  try {
+    return _completeProxy!(a, b);
+  } catch (e) {
+    _future_from_dart__complete_proxy__set_error!(e);
+    return;
+  }
 }

--- a/flutter/lib/src/native/ffi/future.g.dart
+++ b/flutter/lib/src/native/ffi/future.g.dart
@@ -32,9 +32,9 @@ void registerFunction(
   );
 }
 
-void _completeProxyProxy(Object a, Pointer b) {
+void _completeProxyProxy(Object arg0, Pointer arg1) {
   try {
-    return _completeProxy!(a, b);
+    return _completeProxy!(arg0, arg1);
   } catch (e) {
     _future_from_dart__complete_proxy__set_error!(e);
     return;

--- a/flutter/lib/src/native/ffi/list.dart
+++ b/flutter/lib/src/native/ffi/list.dart
@@ -7,15 +7,15 @@ import 'list.g.dart' as bridge;
 void registerFunctions(DynamicLibrary dl) {
   bridge.registerFunction(
     dl,
-    get: Pointer.fromFunction(_get),
-    length: Pointer.fromFunction(_len, 0),
-    add: Pointer.fromFunction(_add),
-    init: Pointer.fromFunction(_init),
+    get: _get,
+    length: _len,
+    add: _add,
+    init: _init,
   );
 }
 
 /// Creates a new empty [List].
-Object _init() {
+List _init() {
   return [];
 }
 

--- a/flutter/lib/src/native/ffi/list.g.dart
+++ b/flutter/lib/src/native/ffi/list.g.dart
@@ -65,18 +65,18 @@ void registerFunction(
   );
 }
 
-Pointer _getProxy(Object a, int b) {
+Pointer _getProxy(Object arg0, int arg1) {
   try {
-    return _get!(a, b);
+    return _get!(arg0, arg1);
   } catch (e) {
     _list__get__set_error!(e);
     return Pointer.fromAddress(0);
   }
 }
 
-int _lengthProxy(Object a) {
+int _lengthProxy(Object arg0) {
   try {
-    return _length!(a);
+    return _length!(arg0);
   } catch (e) {
     _list__length__set_error!(e);
     return 0;
@@ -92,9 +92,9 @@ Object _initProxy() {
   }
 }
 
-void _addProxy(Object a, ForeignValue b) {
+void _addProxy(Object arg0, ForeignValue arg1) {
   try {
-    return _add!(a, b);
+    return _add!(arg0, arg1);
   } catch (e) {
     _list__add__set_error!(e);
     return;

--- a/flutter/lib/src/native/ffi/list.g.dart
+++ b/flutter/lib/src/native/ffi/list.g.dart
@@ -4,18 +4,99 @@ import 'package:ffi/ffi.dart';
 
 import 'package:medea_jason/src/native/ffi/foreign_value.dart';
 
+typedef _ErrorSetterFnC = Void Function(Handle);
+typedef _ErrorSetterFnDart = void Function(Object);
+
+Pointer Function(Object, int)? _get;
+int Function(Object)? _length;
+Object Function()? _init;
+void Function(Object, ForeignValue)? _add;
+
+_ErrorSetterFnDart? _list__get__set_error;
+_ErrorSetterFnDart? _list__length__set_error;
+_ErrorSetterFnDart? _list__init__set_error;
+_ErrorSetterFnDart? _list__add__set_error;
+
 void registerFunction(
   DynamicLibrary dl, {
-  required Pointer<NativeFunction<Pointer Function(Handle, Uint32)>> get,
-  required Pointer<NativeFunction<Uint32 Function(Handle)>> length,
-  required Pointer<NativeFunction<Handle Function()>> init,
-  required Pointer<NativeFunction<Void Function(Handle, ForeignValue)>> add,
+  required Pointer Function(Object, int) get,
+  required int Function(Object) length,
+  required Object Function() init,
+  required void Function(Object, ForeignValue) add,
 }) {
+  _get = get;
+  _length = length;
+  _init = init;
+  _add = add;
+
+  _list__get__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'list__get__set_error');
+  _list__length__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'list__length__set_error');
+  _list__init__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'list__init__set_error');
+  _list__add__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'list__add__set_error');
+
+  Pointer<NativeFunction<Pointer Function(Handle, Uint32)>> get_native =
+      Pointer.fromFunction(
+    _getProxy,
+  );
+  Pointer<NativeFunction<Uint32 Function(Handle)>> length_native =
+      Pointer.fromFunction(_lengthProxy, 0);
+  Pointer<NativeFunction<Handle Function()>> init_native = Pointer.fromFunction(
+    _initProxy,
+  );
+  Pointer<NativeFunction<Void Function(Handle, ForeignValue)>> add_native =
+      Pointer.fromFunction(
+    _addProxy,
+  );
+
   dl.lookupFunction<Void Function(Pointer, Pointer, Pointer, Pointer),
       void Function(Pointer, Pointer, Pointer, Pointer)>('register_list')(
-    get,
-    length,
-    init,
-    add,
+    get_native,
+    length_native,
+    init_native,
+    add_native,
   );
+}
+
+Pointer _getProxy(Object a, int b) {
+  try {
+    return _get!(a, b);
+  } catch (e) {
+    _list__get__set_error!(e);
+    return Pointer.fromAddress(0);
+  }
+}
+
+int _lengthProxy(Object a) {
+  try {
+    return _length!(a);
+  } catch (e) {
+    _list__length__set_error!(e);
+    return 0;
+  }
+}
+
+Object _initProxy() {
+  try {
+    return _init!();
+  } catch (e) {
+    _list__init__set_error!(e);
+    return 0;
+  }
+}
+
+void _addProxy(Object a, ForeignValue b) {
+  try {
+    return _add!(a, b);
+  } catch (e) {
+    _list__add__set_error!(e);
+    return;
+  }
 }

--- a/flutter/lib/src/native/ffi/map.dart
+++ b/flutter/lib/src/native/ffi/map.dart
@@ -8,12 +8,11 @@ import 'map.g.dart' as bridge;
 
 /// Registers functions allowing Rust to create Dart [Map]s.
 void registerFunctions(DynamicLibrary dl) {
-  bridge.registerFunction(dl,
-      init: Pointer.fromFunction(_init), set: Pointer.fromFunction(_set));
+  bridge.registerFunction(dl, init: _init, set: _set);
 }
 
 /// Returns an empty [Map].
-Object _init() {
+Map _init() {
   return {};
 }
 

--- a/flutter/lib/src/native/ffi/map.g.dart
+++ b/flutter/lib/src/native/ffi/map.g.dart
@@ -51,9 +51,9 @@ Object _initProxy() {
   }
 }
 
-void _setProxy(Object a, Pointer<Utf8> b, ForeignValue c) {
+void _setProxy(Object arg0, Pointer<Utf8> arg1, ForeignValue arg2) {
   try {
-    return _set!(a, b, c);
+    return _set!(arg0, arg1, arg2);
   } catch (e) {
     _map__set__set_error!(e);
     return;

--- a/flutter/lib/src/native/ffi/map.g.dart
+++ b/flutter/lib/src/native/ffi/map.g.dart
@@ -4,16 +4,58 @@ import 'package:ffi/ffi.dart';
 
 import 'package:medea_jason/src/native/ffi/foreign_value.dart';
 
+typedef _ErrorSetterFnC = Void Function(Handle);
+typedef _ErrorSetterFnDart = void Function(Object);
+
+Object Function()? _init;
+void Function(Object, Pointer<Utf8>, ForeignValue)? _set;
+
+_ErrorSetterFnDart? _map__init__set_error;
+_ErrorSetterFnDart? _map__set__set_error;
+
 void registerFunction(
   DynamicLibrary dl, {
-  required Pointer<NativeFunction<Handle Function()>> init,
-  required Pointer<
-          NativeFunction<Void Function(Handle, Pointer<Utf8>, ForeignValue)>>
-      set,
+  required Object Function() init,
+  required void Function(Object, Pointer<Utf8>, ForeignValue) set,
 }) {
+  _init = init;
+  _set = set;
+
+  _map__init__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'map__init__set_error');
+  _map__set__set_error = dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+      'map__set__set_error');
+
+  Pointer<NativeFunction<Handle Function()>> init_native = Pointer.fromFunction(
+    _initProxy,
+  );
+  Pointer<NativeFunction<Void Function(Handle, Pointer<Utf8>, ForeignValue)>>
+      set_native = Pointer.fromFunction(
+    _setProxy,
+  );
+
   dl.lookupFunction<Void Function(Pointer, Pointer),
       void Function(Pointer, Pointer)>('register_map')(
-    init,
-    set,
+    init_native,
+    set_native,
   );
+}
+
+Object _initProxy() {
+  try {
+    return _init!();
+  } catch (e) {
+    _map__init__set_error!(e);
+    return 0;
+  }
+}
+
+void _setProxy(Object a, Pointer<Utf8> b, ForeignValue c) {
+  try {
+    return _set!(a, b, c);
+  } catch (e) {
+    _map__set__set_error!(e);
+    return;
+  }
 }

--- a/flutter/lib/src/native/platform/codec_capability.dart
+++ b/flutter/lib/src/native/platform/codec_capability.dart
@@ -9,14 +9,14 @@ import 'codec_capability.g.dart' as bridge;
 void registerFunctions(DynamicLibrary dl) {
   bridge.registerFunction(
     dl,
-    getSenderCodecCapabilities:
-        Pointer.fromFunction(_getSenderCodecCapabilities),
-    mimeType: Pointer.fromFunction(_mimeType),
+    getSenderCodecCapabilities: _getSenderCodecCapabilities,
+    mimeType: _mimeType,
   );
 }
 
 /// Returns available [RtpCodecCapability]s for an [RtpSender].
-Object _getSenderCodecCapabilities(int kind) {
+Future<List<RtpCodecCapability>> Function() _getSenderCodecCapabilities(
+    int kind) {
   return () => RtpSender.getCapabilities(MediaKind.values[kind])
       .then((res) => res.codecs);
 }

--- a/flutter/lib/src/native/platform/codec_capability.g.dart
+++ b/flutter/lib/src/native/platform/codec_capability.g.dart
@@ -4,15 +4,60 @@ import 'package:ffi/ffi.dart';
 
 import 'package:medea_jason/src/native/ffi/foreign_value.dart';
 
+typedef _ErrorSetterFnC = Void Function(Handle);
+typedef _ErrorSetterFnDart = void Function(Object);
+
+Object Function(int)? _getSenderCodecCapabilities;
+Pointer<Utf8> Function(Object)? _mimeType;
+
+_ErrorSetterFnDart? _codec_capability__get_sender_codec_capabilities__set_error;
+_ErrorSetterFnDart? _codec_capability__mime_type__set_error;
+
 void registerFunction(
   DynamicLibrary dl, {
-  required Pointer<NativeFunction<Handle Function(Int64)>>
-      getSenderCodecCapabilities,
-  required Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> mimeType,
+  required Object Function(int) getSenderCodecCapabilities,
+  required Pointer<Utf8> Function(Object) mimeType,
 }) {
+  _getSenderCodecCapabilities = getSenderCodecCapabilities;
+  _mimeType = mimeType;
+
+  _codec_capability__get_sender_codec_capabilities__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'codec_capability__get_sender_codec_capabilities__set_error');
+  _codec_capability__mime_type__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'codec_capability__mime_type__set_error');
+
+  Pointer<NativeFunction<Handle Function(Int64)>>
+      getSenderCodecCapabilities_native = Pointer.fromFunction(
+    _getSenderCodecCapabilitiesProxy,
+  );
+  Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> mimeType_native =
+      Pointer.fromFunction(
+    _mimeTypeProxy,
+  );
+
   dl.lookupFunction<Void Function(Pointer, Pointer),
       void Function(Pointer, Pointer)>('register_codec_capability')(
-    getSenderCodecCapabilities,
-    mimeType,
+    getSenderCodecCapabilities_native,
+    mimeType_native,
   );
+}
+
+Object _getSenderCodecCapabilitiesProxy(int a) {
+  try {
+    return _getSenderCodecCapabilities!(a);
+  } catch (e) {
+    _codec_capability__get_sender_codec_capabilities__set_error!(e);
+    return 0;
+  }
+}
+
+Pointer<Utf8> _mimeTypeProxy(Object a) {
+  try {
+    return _mimeType!(a);
+  } catch (e) {
+    _codec_capability__mime_type__set_error!(e);
+    return Pointer.fromAddress(0);
+  }
 }

--- a/flutter/lib/src/native/platform/codec_capability.g.dart
+++ b/flutter/lib/src/native/platform/codec_capability.g.dart
@@ -44,18 +44,18 @@ void registerFunction(
   );
 }
 
-Object _getSenderCodecCapabilitiesProxy(int a) {
+Object _getSenderCodecCapabilitiesProxy(int arg0) {
   try {
-    return _getSenderCodecCapabilities!(a);
+    return _getSenderCodecCapabilities!(arg0);
   } catch (e) {
     _codec_capability__get_sender_codec_capabilities__set_error!(e);
     return 0;
   }
 }
 
-Pointer<Utf8> _mimeTypeProxy(Object a) {
+Pointer<Utf8> _mimeTypeProxy(Object arg0) {
   try {
-    return _mimeType!(a);
+    return _mimeType!(arg0);
   } catch (e) {
     _codec_capability__mime_type__set_error!(e);
     return Pointer.fromAddress(0);

--- a/flutter/lib/src/native/platform/constraints.dart
+++ b/flutter/lib/src/native/platform/constraints.dart
@@ -12,15 +12,15 @@ import 'constraints.g.dart' as bridge;
 void registerFunctions(DynamicLibrary dl) {
   bridge.registerFunction(
     dl,
-    initDeviceConstraints: Pointer.fromFunction(_newDeviceConstraints),
-    initDisplayConstraints: Pointer.fromFunction(_newDisplayConstraints),
-    newVideoConstraints: Pointer.fromFunction(_newVideoConstraints),
-    newAudioConstraints: Pointer.fromFunction(_newAudioConstraints),
-    setVideoConstraintValue: Pointer.fromFunction(_setVideoConstraintValue),
-    setAudioConstraintValue: Pointer.fromFunction(_setAudioConstraintValue),
-    setVideoConstraint: Pointer.fromFunction(_setVideoConstraint),
-    setAudioConstraint: Pointer.fromFunction(_setAudioConstraint),
-    setDisplayVideoConstraint: Pointer.fromFunction(_setDisplayVideoConstraint),
+    initDeviceConstraints: _newDeviceConstraints,
+    initDisplayConstraints: _newDisplayConstraints,
+    newVideoConstraints: _newVideoConstraints,
+    newAudioConstraints: _newAudioConstraints,
+    setVideoConstraintValue: _setVideoConstraintValue,
+    setAudioConstraintValue: _setAudioConstraintValue,
+    setVideoConstraint: _setVideoConstraint,
+    setAudioConstraint: _setAudioConstraint,
+    setDisplayVideoConstraint: _setDisplayVideoConstraint,
   );
 }
 
@@ -52,22 +52,22 @@ enum ConstraintType {
 }
 
 /// Returns new empty [DeviceConstraints].
-Object _newDeviceConstraints() {
+webrtc.DeviceConstraints _newDeviceConstraints() {
   return webrtc.DeviceConstraints();
 }
 
 ///Returns new empty [DisplayConstraints].
-Object _newDisplayConstraints() {
+webrtc.DisplayConstraints _newDisplayConstraints() {
   return webrtc.DisplayConstraints();
 }
 
 /// Returns new empty [DeviceVideoConstraints].
-Object _newVideoConstraints() {
+webrtc.DeviceVideoConstraints _newVideoConstraints() {
   return webrtc.DeviceVideoConstraints();
 }
 
 /// Returns new empty [AudioConstraints].
-Object _newAudioConstraints() {
+webrtc.AudioConstraints _newAudioConstraints() {
   return webrtc.AudioConstraints();
 }
 

--- a/flutter/lib/src/native/platform/constraints.g.dart
+++ b/flutter/lib/src/native/platform/constraints.g.dart
@@ -4,36 +4,210 @@ import 'package:ffi/ffi.dart';
 
 import 'package:medea_jason/src/native/ffi/foreign_value.dart';
 
+typedef _ErrorSetterFnC = Void Function(Handle);
+typedef _ErrorSetterFnDart = void Function(Object);
+
+Object Function()? _initDeviceConstraints;
+Object Function()? _initDisplayConstraints;
+Object Function()? _newVideoConstraints;
+Object Function()? _newAudioConstraints;
+void Function(Object, int, ForeignValue)? _setVideoConstraintValue;
+void Function(Object, int, ForeignValue)? _setAudioConstraintValue;
+void Function(Object, int, Object)? _setVideoConstraint;
+void Function(Object, int, Object)? _setDisplayVideoConstraint;
+void Function(Object, int, Object)? _setAudioConstraint;
+
+_ErrorSetterFnDart? _constraints__init_device_constraints__set_error;
+_ErrorSetterFnDart? _constraints__init_display_constraints__set_error;
+_ErrorSetterFnDart? _constraints__new_video_constraints__set_error;
+_ErrorSetterFnDart? _constraints__new_audio_constraints__set_error;
+_ErrorSetterFnDart? _constraints__set_video_constraint_value__set_error;
+_ErrorSetterFnDart? _constraints__set_audio_constraint_value__set_error;
+_ErrorSetterFnDart? _constraints__set_video_constraint__set_error;
+_ErrorSetterFnDart? _constraints__set_display_video_constraint__set_error;
+_ErrorSetterFnDart? _constraints__set_audio_constraint__set_error;
+
 void registerFunction(
   DynamicLibrary dl, {
-  required Pointer<NativeFunction<Handle Function()>> initDeviceConstraints,
-  required Pointer<NativeFunction<Handle Function()>> initDisplayConstraints,
-  required Pointer<NativeFunction<Handle Function()>> newVideoConstraints,
-  required Pointer<NativeFunction<Handle Function()>> newAudioConstraints,
-  required Pointer<NativeFunction<Void Function(Handle, Int64, ForeignValue)>>
-      setVideoConstraintValue,
-  required Pointer<NativeFunction<Void Function(Handle, Int64, ForeignValue)>>
-      setAudioConstraintValue,
-  required Pointer<NativeFunction<Void Function(Handle, Int64, Handle)>>
-      setVideoConstraint,
-  required Pointer<NativeFunction<Void Function(Handle, Int64, Handle)>>
-      setDisplayVideoConstraint,
-  required Pointer<NativeFunction<Void Function(Handle, Int64, Handle)>>
-      setAudioConstraint,
+  required Object Function() initDeviceConstraints,
+  required Object Function() initDisplayConstraints,
+  required Object Function() newVideoConstraints,
+  required Object Function() newAudioConstraints,
+  required void Function(Object, int, ForeignValue) setVideoConstraintValue,
+  required void Function(Object, int, ForeignValue) setAudioConstraintValue,
+  required void Function(Object, int, Object) setVideoConstraint,
+  required void Function(Object, int, Object) setDisplayVideoConstraint,
+  required void Function(Object, int, Object) setAudioConstraint,
 }) {
+  _initDeviceConstraints = initDeviceConstraints;
+  _initDisplayConstraints = initDisplayConstraints;
+  _newVideoConstraints = newVideoConstraints;
+  _newAudioConstraints = newAudioConstraints;
+  _setVideoConstraintValue = setVideoConstraintValue;
+  _setAudioConstraintValue = setAudioConstraintValue;
+  _setVideoConstraint = setVideoConstraint;
+  _setDisplayVideoConstraint = setDisplayVideoConstraint;
+  _setAudioConstraint = setAudioConstraint;
+
+  _constraints__init_device_constraints__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'constraints__init_device_constraints__set_error');
+  _constraints__init_display_constraints__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'constraints__init_display_constraints__set_error');
+  _constraints__new_video_constraints__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'constraints__new_video_constraints__set_error');
+  _constraints__new_audio_constraints__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'constraints__new_audio_constraints__set_error');
+  _constraints__set_video_constraint_value__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'constraints__set_video_constraint_value__set_error');
+  _constraints__set_audio_constraint_value__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'constraints__set_audio_constraint_value__set_error');
+  _constraints__set_video_constraint__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'constraints__set_video_constraint__set_error');
+  _constraints__set_display_video_constraint__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'constraints__set_display_video_constraint__set_error');
+  _constraints__set_audio_constraint__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'constraints__set_audio_constraint__set_error');
+
+  Pointer<NativeFunction<Handle Function()>> initDeviceConstraints_native =
+      Pointer.fromFunction(
+    _initDeviceConstraintsProxy,
+  );
+  Pointer<NativeFunction<Handle Function()>> initDisplayConstraints_native =
+      Pointer.fromFunction(
+    _initDisplayConstraintsProxy,
+  );
+  Pointer<NativeFunction<Handle Function()>> newVideoConstraints_native =
+      Pointer.fromFunction(
+    _newVideoConstraintsProxy,
+  );
+  Pointer<NativeFunction<Handle Function()>> newAudioConstraints_native =
+      Pointer.fromFunction(
+    _newAudioConstraintsProxy,
+  );
+  Pointer<NativeFunction<Void Function(Handle, Int64, ForeignValue)>>
+      setVideoConstraintValue_native = Pointer.fromFunction(
+    _setVideoConstraintValueProxy,
+  );
+  Pointer<NativeFunction<Void Function(Handle, Int64, ForeignValue)>>
+      setAudioConstraintValue_native = Pointer.fromFunction(
+    _setAudioConstraintValueProxy,
+  );
+  Pointer<NativeFunction<Void Function(Handle, Int64, Handle)>>
+      setVideoConstraint_native = Pointer.fromFunction(
+    _setVideoConstraintProxy,
+  );
+  Pointer<NativeFunction<Void Function(Handle, Int64, Handle)>>
+      setDisplayVideoConstraint_native = Pointer.fromFunction(
+    _setDisplayVideoConstraintProxy,
+  );
+  Pointer<NativeFunction<Void Function(Handle, Int64, Handle)>>
+      setAudioConstraint_native = Pointer.fromFunction(
+    _setAudioConstraintProxy,
+  );
+
   dl.lookupFunction<
       Void Function(Pointer, Pointer, Pointer, Pointer, Pointer, Pointer,
           Pointer, Pointer, Pointer),
       void Function(Pointer, Pointer, Pointer, Pointer, Pointer, Pointer,
           Pointer, Pointer, Pointer)>('register_constraints')(
-    initDeviceConstraints,
-    initDisplayConstraints,
-    newVideoConstraints,
-    newAudioConstraints,
-    setVideoConstraintValue,
-    setAudioConstraintValue,
-    setVideoConstraint,
-    setDisplayVideoConstraint,
-    setAudioConstraint,
+    initDeviceConstraints_native,
+    initDisplayConstraints_native,
+    newVideoConstraints_native,
+    newAudioConstraints_native,
+    setVideoConstraintValue_native,
+    setAudioConstraintValue_native,
+    setVideoConstraint_native,
+    setDisplayVideoConstraint_native,
+    setAudioConstraint_native,
   );
+}
+
+Object _initDeviceConstraintsProxy() {
+  try {
+    return _initDeviceConstraints!();
+  } catch (e) {
+    _constraints__init_device_constraints__set_error!(e);
+    return 0;
+  }
+}
+
+Object _initDisplayConstraintsProxy() {
+  try {
+    return _initDisplayConstraints!();
+  } catch (e) {
+    _constraints__init_display_constraints__set_error!(e);
+    return 0;
+  }
+}
+
+Object _newVideoConstraintsProxy() {
+  try {
+    return _newVideoConstraints!();
+  } catch (e) {
+    _constraints__new_video_constraints__set_error!(e);
+    return 0;
+  }
+}
+
+Object _newAudioConstraintsProxy() {
+  try {
+    return _newAudioConstraints!();
+  } catch (e) {
+    _constraints__new_audio_constraints__set_error!(e);
+    return 0;
+  }
+}
+
+void _setVideoConstraintValueProxy(Object a, int b, ForeignValue c) {
+  try {
+    return _setVideoConstraintValue!(a, b, c);
+  } catch (e) {
+    _constraints__set_video_constraint_value__set_error!(e);
+    return;
+  }
+}
+
+void _setAudioConstraintValueProxy(Object a, int b, ForeignValue c) {
+  try {
+    return _setAudioConstraintValue!(a, b, c);
+  } catch (e) {
+    _constraints__set_audio_constraint_value__set_error!(e);
+    return;
+  }
+}
+
+void _setVideoConstraintProxy(Object a, int b, Object c) {
+  try {
+    return _setVideoConstraint!(a, b, c);
+  } catch (e) {
+    _constraints__set_video_constraint__set_error!(e);
+    return;
+  }
+}
+
+void _setDisplayVideoConstraintProxy(Object a, int b, Object c) {
+  try {
+    return _setDisplayVideoConstraint!(a, b, c);
+  } catch (e) {
+    _constraints__set_display_video_constraint__set_error!(e);
+    return;
+  }
+}
+
+void _setAudioConstraintProxy(Object a, int b, Object c) {
+  try {
+    return _setAudioConstraint!(a, b, c);
+  } catch (e) {
+    _constraints__set_audio_constraint__set_error!(e);
+    return;
+  }
 }

--- a/flutter/lib/src/native/platform/constraints.g.dart
+++ b/flutter/lib/src/native/platform/constraints.g.dart
@@ -167,45 +167,45 @@ Object _newAudioConstraintsProxy() {
   }
 }
 
-void _setVideoConstraintValueProxy(Object a, int b, ForeignValue c) {
+void _setVideoConstraintValueProxy(Object arg0, int arg1, ForeignValue arg2) {
   try {
-    return _setVideoConstraintValue!(a, b, c);
+    return _setVideoConstraintValue!(arg0, arg1, arg2);
   } catch (e) {
     _constraints__set_video_constraint_value__set_error!(e);
     return;
   }
 }
 
-void _setAudioConstraintValueProxy(Object a, int b, ForeignValue c) {
+void _setAudioConstraintValueProxy(Object arg0, int arg1, ForeignValue arg2) {
   try {
-    return _setAudioConstraintValue!(a, b, c);
+    return _setAudioConstraintValue!(arg0, arg1, arg2);
   } catch (e) {
     _constraints__set_audio_constraint_value__set_error!(e);
     return;
   }
 }
 
-void _setVideoConstraintProxy(Object a, int b, Object c) {
+void _setVideoConstraintProxy(Object arg0, int arg1, Object arg2) {
   try {
-    return _setVideoConstraint!(a, b, c);
+    return _setVideoConstraint!(arg0, arg1, arg2);
   } catch (e) {
     _constraints__set_video_constraint__set_error!(e);
     return;
   }
 }
 
-void _setDisplayVideoConstraintProxy(Object a, int b, Object c) {
+void _setDisplayVideoConstraintProxy(Object arg0, int arg1, Object arg2) {
   try {
-    return _setDisplayVideoConstraint!(a, b, c);
+    return _setDisplayVideoConstraint!(arg0, arg1, arg2);
   } catch (e) {
     _constraints__set_display_video_constraint__set_error!(e);
     return;
   }
 }
 
-void _setAudioConstraintProxy(Object a, int b, Object c) {
+void _setAudioConstraintProxy(Object arg0, int arg1, Object arg2) {
   try {
-    return _setAudioConstraint!(a, b, c);
+    return _setAudioConstraint!(arg0, arg1, arg2);
   } catch (e) {
     _constraints__set_audio_constraint__set_error!(e);
     return;

--- a/flutter/lib/src/native/platform/ice_candidate.dart
+++ b/flutter/lib/src/native/platform/ice_candidate.dart
@@ -10,10 +10,10 @@ import 'ice_candidate.g.dart' as bridge;
 void registerFunctions(DynamicLibrary dl) {
   bridge.registerFunction(
     dl,
-    init: Pointer.fromFunction(_new),
-    candidate: Pointer.fromFunction(_candidate),
-    sdpMLineIndex: Pointer.fromFunction(_sdpMLineIndex, 0),
-    sdpMid: Pointer.fromFunction(_sdpMid),
+    init: _new,
+    candidate: _candidate,
+    sdpMLineIndex: _sdpMLineIndex,
+    sdpMid: _sdpMid,
   );
 }
 
@@ -37,7 +37,7 @@ Pointer<Utf8> _sdpMid(Object iceCandidate) {
 }
 
 /// Creates a new [IceCandidate] with the provided values.
-Object _new(
+webrtc.IceCandidate _new(
     ForeignValue candidate, ForeignValue sdpMid, ForeignValue sdpMlineIndex) {
   var candidateArg = candidate.toDart();
   var sdpMidArg = sdpMid.toDart();

--- a/flutter/lib/src/native/platform/ice_candidate.g.dart
+++ b/flutter/lib/src/native/platform/ice_candidate.g.dart
@@ -4,23 +4,104 @@ import 'package:ffi/ffi.dart';
 
 import 'package:medea_jason/src/native/ffi/foreign_value.dart';
 
+typedef _ErrorSetterFnC = Void Function(Handle);
+typedef _ErrorSetterFnDart = void Function(Object);
+
+Object Function(ForeignValue, ForeignValue, ForeignValue)? _init;
+Pointer<Utf8> Function(Object)? _candidate;
+int Function(Object)? _sdpMLineIndex;
+Pointer<Utf8> Function(Object)? _sdpMid;
+
+_ErrorSetterFnDart? _ice_candidate__init__set_error;
+_ErrorSetterFnDart? _ice_candidate__candidate__set_error;
+_ErrorSetterFnDart? _ice_candidate__sdp_m_line_index__set_error;
+_ErrorSetterFnDart? _ice_candidate__sdp_mid__set_error;
+
 void registerFunction(
   DynamicLibrary dl, {
-  required Pointer<
+  required Object Function(ForeignValue, ForeignValue, ForeignValue) init,
+  required Pointer<Utf8> Function(Object) candidate,
+  required int Function(Object) sdpMLineIndex,
+  required Pointer<Utf8> Function(Object) sdpMid,
+}) {
+  _init = init;
+  _candidate = candidate;
+  _sdpMLineIndex = sdpMLineIndex;
+  _sdpMid = sdpMid;
+
+  _ice_candidate__init__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'ice_candidate__init__set_error');
+  _ice_candidate__candidate__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'ice_candidate__candidate__set_error');
+  _ice_candidate__sdp_m_line_index__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'ice_candidate__sdp_m_line_index__set_error');
+  _ice_candidate__sdp_mid__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'ice_candidate__sdp_mid__set_error');
+
+  Pointer<
           NativeFunction<
               Handle Function(ForeignValue, ForeignValue, ForeignValue)>>
-      init,
-  required Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> candidate,
-  required Pointer<NativeFunction<Uint64 Function(Handle)>> sdpMLineIndex,
-  required Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> sdpMid,
-}) {
+      init_native = Pointer.fromFunction(
+    _initProxy,
+  );
+  Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> candidate_native =
+      Pointer.fromFunction(
+    _candidateProxy,
+  );
+  Pointer<NativeFunction<Uint64 Function(Handle)>> sdpMLineIndex_native =
+      Pointer.fromFunction(_sdpMLineIndexProxy, 0);
+  Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> sdpMid_native =
+      Pointer.fromFunction(
+    _sdpMidProxy,
+  );
+
   dl.lookupFunction<
       Void Function(Pointer, Pointer, Pointer, Pointer),
       void Function(
           Pointer, Pointer, Pointer, Pointer)>('register_ice_candidate')(
-    init,
-    candidate,
-    sdpMLineIndex,
-    sdpMid,
+    init_native,
+    candidate_native,
+    sdpMLineIndex_native,
+    sdpMid_native,
   );
+}
+
+Object _initProxy(ForeignValue a, ForeignValue b, ForeignValue c) {
+  try {
+    return _init!(a, b, c);
+  } catch (e) {
+    _ice_candidate__init__set_error!(e);
+    return 0;
+  }
+}
+
+Pointer<Utf8> _candidateProxy(Object a) {
+  try {
+    return _candidate!(a);
+  } catch (e) {
+    _ice_candidate__candidate__set_error!(e);
+    return Pointer.fromAddress(0);
+  }
+}
+
+int _sdpMLineIndexProxy(Object a) {
+  try {
+    return _sdpMLineIndex!(a);
+  } catch (e) {
+    _ice_candidate__sdp_m_line_index__set_error!(e);
+    return 0;
+  }
+}
+
+Pointer<Utf8> _sdpMidProxy(Object a) {
+  try {
+    return _sdpMid!(a);
+  } catch (e) {
+    _ice_candidate__sdp_mid__set_error!(e);
+    return Pointer.fromAddress(0);
+  }
 }

--- a/flutter/lib/src/native/platform/ice_candidate.g.dart
+++ b/flutter/lib/src/native/platform/ice_candidate.g.dart
@@ -70,36 +70,36 @@ void registerFunction(
   );
 }
 
-Object _initProxy(ForeignValue a, ForeignValue b, ForeignValue c) {
+Object _initProxy(ForeignValue arg0, ForeignValue arg1, ForeignValue arg2) {
   try {
-    return _init!(a, b, c);
+    return _init!(arg0, arg1, arg2);
   } catch (e) {
     _ice_candidate__init__set_error!(e);
     return 0;
   }
 }
 
-Pointer<Utf8> _candidateProxy(Object a) {
+Pointer<Utf8> _candidateProxy(Object arg0) {
   try {
-    return _candidate!(a);
+    return _candidate!(arg0);
   } catch (e) {
     _ice_candidate__candidate__set_error!(e);
     return Pointer.fromAddress(0);
   }
 }
 
-int _sdpMLineIndexProxy(Object a) {
+int _sdpMLineIndexProxy(Object arg0) {
   try {
-    return _sdpMLineIndex!(a);
+    return _sdpMLineIndex!(arg0);
   } catch (e) {
     _ice_candidate__sdp_m_line_index__set_error!(e);
     return 0;
   }
 }
 
-Pointer<Utf8> _sdpMidProxy(Object a) {
+Pointer<Utf8> _sdpMidProxy(Object arg0) {
   try {
-    return _sdpMid!(a);
+    return _sdpMid!(arg0);
   } catch (e) {
     _ice_candidate__sdp_mid__set_error!(e);
     return Pointer.fromAddress(0);

--- a/flutter/lib/src/native/platform/ice_candidate_error.dart
+++ b/flutter/lib/src/native/platform/ice_candidate_error.dart
@@ -9,11 +9,11 @@ import 'ice_candidate_error.g.dart' as bridge;
 void registerFunctions(DynamicLibrary dl) {
   bridge.registerFunction(
     dl,
-    address: Pointer.fromFunction(_address),
-    port: Pointer.fromFunction(_port, 0),
-    url: Pointer.fromFunction(_url),
-    errorCode: Pointer.fromFunction(_errorCode, 0),
-    errorText: Pointer.fromFunction(_errorText),
+    address: _address,
+    port: _port,
+    url: _url,
+    errorCode: _errorCode,
+    errorText: _errorText,
   );
 }
 

--- a/flutter/lib/src/native/platform/ice_candidate_error.g.dart
+++ b/flutter/lib/src/native/platform/ice_candidate_error.g.dart
@@ -78,45 +78,45 @@ void registerFunction(
   );
 }
 
-Pointer<Utf8> _addressProxy(Object a) {
+Pointer<Utf8> _addressProxy(Object arg0) {
   try {
-    return _address!(a);
+    return _address!(arg0);
   } catch (e) {
     _ice_candidate_error__address__set_error!(e);
     return Pointer.fromAddress(0);
   }
 }
 
-int _portProxy(Object a) {
+int _portProxy(Object arg0) {
   try {
-    return _port!(a);
+    return _port!(arg0);
   } catch (e) {
     _ice_candidate_error__port__set_error!(e);
     return 0;
   }
 }
 
-Pointer<Utf8> _urlProxy(Object a) {
+Pointer<Utf8> _urlProxy(Object arg0) {
   try {
-    return _url!(a);
+    return _url!(arg0);
   } catch (e) {
     _ice_candidate_error__url__set_error!(e);
     return Pointer.fromAddress(0);
   }
 }
 
-int _errorCodeProxy(Object a) {
+int _errorCodeProxy(Object arg0) {
   try {
-    return _errorCode!(a);
+    return _errorCode!(arg0);
   } catch (e) {
     _ice_candidate_error__error_code__set_error!(e);
     return 0;
   }
 }
 
-Pointer<Utf8> _errorTextProxy(Object a) {
+Pointer<Utf8> _errorTextProxy(Object arg0) {
   try {
-    return _errorText!(a);
+    return _errorText!(arg0);
   } catch (e) {
     _ice_candidate_error__error_text__set_error!(e);
     return Pointer.fromAddress(0);

--- a/flutter/lib/src/native/platform/ice_candidate_error.g.dart
+++ b/flutter/lib/src/native/platform/ice_candidate_error.g.dart
@@ -4,22 +4,121 @@ import 'package:ffi/ffi.dart';
 
 import 'package:medea_jason/src/native/ffi/foreign_value.dart';
 
+typedef _ErrorSetterFnC = Void Function(Handle);
+typedef _ErrorSetterFnDart = void Function(Object);
+
+Pointer<Utf8> Function(Object)? _address;
+int Function(Object)? _port;
+Pointer<Utf8> Function(Object)? _url;
+int Function(Object)? _errorCode;
+Pointer<Utf8> Function(Object)? _errorText;
+
+_ErrorSetterFnDart? _ice_candidate_error__address__set_error;
+_ErrorSetterFnDart? _ice_candidate_error__port__set_error;
+_ErrorSetterFnDart? _ice_candidate_error__url__set_error;
+_ErrorSetterFnDart? _ice_candidate_error__error_code__set_error;
+_ErrorSetterFnDart? _ice_candidate_error__error_text__set_error;
+
 void registerFunction(
   DynamicLibrary dl, {
-  required Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> address,
-  required Pointer<NativeFunction<Uint32 Function(Handle)>> port,
-  required Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> url,
-  required Pointer<NativeFunction<Int32 Function(Handle)>> errorCode,
-  required Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> errorText,
+  required Pointer<Utf8> Function(Object) address,
+  required int Function(Object) port,
+  required Pointer<Utf8> Function(Object) url,
+  required int Function(Object) errorCode,
+  required Pointer<Utf8> Function(Object) errorText,
 }) {
+  _address = address;
+  _port = port;
+  _url = url;
+  _errorCode = errorCode;
+  _errorText = errorText;
+
+  _ice_candidate_error__address__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'ice_candidate_error__address__set_error');
+  _ice_candidate_error__port__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'ice_candidate_error__port__set_error');
+  _ice_candidate_error__url__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'ice_candidate_error__url__set_error');
+  _ice_candidate_error__error_code__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'ice_candidate_error__error_code__set_error');
+  _ice_candidate_error__error_text__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'ice_candidate_error__error_text__set_error');
+
+  Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> address_native =
+      Pointer.fromFunction(
+    _addressProxy,
+  );
+  Pointer<NativeFunction<Uint32 Function(Handle)>> port_native =
+      Pointer.fromFunction(_portProxy, 0);
+  Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> url_native =
+      Pointer.fromFunction(
+    _urlProxy,
+  );
+  Pointer<NativeFunction<Int32 Function(Handle)>> errorCode_native =
+      Pointer.fromFunction(_errorCodeProxy, 0);
+  Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> errorText_native =
+      Pointer.fromFunction(
+    _errorTextProxy,
+  );
+
   dl.lookupFunction<
       Void Function(Pointer, Pointer, Pointer, Pointer, Pointer),
       void Function(Pointer, Pointer, Pointer, Pointer,
           Pointer)>('register_ice_candidate_error')(
-    address,
-    port,
-    url,
-    errorCode,
-    errorText,
+    address_native,
+    port_native,
+    url_native,
+    errorCode_native,
+    errorText_native,
   );
+}
+
+Pointer<Utf8> _addressProxy(Object a) {
+  try {
+    return _address!(a);
+  } catch (e) {
+    _ice_candidate_error__address__set_error!(e);
+    return Pointer.fromAddress(0);
+  }
+}
+
+int _portProxy(Object a) {
+  try {
+    return _port!(a);
+  } catch (e) {
+    _ice_candidate_error__port__set_error!(e);
+    return 0;
+  }
+}
+
+Pointer<Utf8> _urlProxy(Object a) {
+  try {
+    return _url!(a);
+  } catch (e) {
+    _ice_candidate_error__url__set_error!(e);
+    return Pointer.fromAddress(0);
+  }
+}
+
+int _errorCodeProxy(Object a) {
+  try {
+    return _errorCode!(a);
+  } catch (e) {
+    _ice_candidate_error__error_code__set_error!(e);
+    return 0;
+  }
+}
+
+Pointer<Utf8> _errorTextProxy(Object a) {
+  try {
+    return _errorText!(a);
+  } catch (e) {
+    _ice_candidate_error__error_text__set_error!(e);
+    return Pointer.fromAddress(0);
+  }
 }

--- a/flutter/lib/src/native/platform/ice_servers.dart
+++ b/flutter/lib/src/native/platform/ice_servers.dart
@@ -11,13 +11,13 @@ import 'ice_servers.g.dart' as bridge;
 void registerFunctions(DynamicLibrary dl) {
   bridge.registerFunction(
     dl,
-    init: Pointer.fromFunction(_new),
-    add: Pointer.fromFunction(_add),
+    init: _new,
+    add: _add,
   );
 }
 
 /// Returns a new empty `IceServer`s [List].
-Object _new() {
+List _new() {
   return List.empty(growable: true);
 }
 

--- a/flutter/lib/src/native/platform/ice_servers.g.dart
+++ b/flutter/lib/src/native/platform/ice_servers.g.dart
@@ -54,9 +54,10 @@ Object _initProxy() {
   }
 }
 
-void _addProxy(Object a, Pointer<Utf8> b, ForeignValue c, ForeignValue d) {
+void _addProxy(
+    Object arg0, Pointer<Utf8> arg1, ForeignValue arg2, ForeignValue arg3) {
   try {
-    return _add!(a, b, c, d);
+    return _add!(arg0, arg1, arg2, arg3);
   } catch (e) {
     _ice_servers__add__set_error!(e);
     return;

--- a/flutter/lib/src/native/platform/ice_servers.g.dart
+++ b/flutter/lib/src/native/platform/ice_servers.g.dart
@@ -4,17 +4,61 @@ import 'package:ffi/ffi.dart';
 
 import 'package:medea_jason/src/native/ffi/foreign_value.dart';
 
+typedef _ErrorSetterFnC = Void Function(Handle);
+typedef _ErrorSetterFnDart = void Function(Object);
+
+Object Function()? _init;
+void Function(Object, Pointer<Utf8>, ForeignValue, ForeignValue)? _add;
+
+_ErrorSetterFnDart? _ice_servers__init__set_error;
+_ErrorSetterFnDart? _ice_servers__add__set_error;
+
 void registerFunction(
   DynamicLibrary dl, {
-  required Pointer<NativeFunction<Handle Function()>> init,
-  required Pointer<
+  required Object Function() init,
+  required void Function(Object, Pointer<Utf8>, ForeignValue, ForeignValue) add,
+}) {
+  _init = init;
+  _add = add;
+
+  _ice_servers__init__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'ice_servers__init__set_error');
+  _ice_servers__add__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'ice_servers__add__set_error');
+
+  Pointer<NativeFunction<Handle Function()>> init_native = Pointer.fromFunction(
+    _initProxy,
+  );
+  Pointer<
           NativeFunction<
               Void Function(Handle, Pointer<Utf8>, ForeignValue, ForeignValue)>>
-      add,
-}) {
+      add_native = Pointer.fromFunction(
+    _addProxy,
+  );
+
   dl.lookupFunction<Void Function(Pointer, Pointer),
       void Function(Pointer, Pointer)>('register_ice_servers')(
-    init,
-    add,
+    init_native,
+    add_native,
   );
+}
+
+Object _initProxy() {
+  try {
+    return _init!();
+  } catch (e) {
+    _ice_servers__init__set_error!(e);
+    return 0;
+  }
+}
+
+void _addProxy(Object a, Pointer<Utf8> b, ForeignValue c, ForeignValue d) {
+  try {
+    return _add!(a, b, c, d);
+  } catch (e) {
+    _ice_servers__add__set_error!(e);
+    return;
+  }
 }

--- a/flutter/lib/src/native/platform/media_device_info.dart
+++ b/flutter/lib/src/native/platform/media_device_info.dart
@@ -10,11 +10,11 @@ import 'media_device_info.g.dart' as bridge;
 void registerFunctions(DynamicLibrary dl) {
   bridge.registerFunction(
     dl,
-    deviceId: Pointer.fromFunction(_deviceId),
-    label: Pointer.fromFunction(_label),
-    groupId: Pointer.fromFunction(_groupId),
-    kind: Pointer.fromFunction(_kind, 2),
-    isFailed: Pointer.fromFunction(_isFailed, true),
+    deviceId: _deviceId,
+    label: _label,
+    groupId: _groupId,
+    kind: _kind,
+    isFailed: _isFailed,
   );
 }
 

--- a/flutter/lib/src/native/platform/media_device_info.g.dart
+++ b/flutter/lib/src/native/platform/media_device_info.g.dart
@@ -78,45 +78,45 @@ void registerFunction(
   );
 }
 
-Pointer<Utf8> _deviceIdProxy(Object a) {
+Pointer<Utf8> _deviceIdProxy(Object arg0) {
   try {
-    return _deviceId!(a);
+    return _deviceId!(arg0);
   } catch (e) {
     _media_device_info__device_id__set_error!(e);
     return Pointer.fromAddress(0);
   }
 }
 
-int _kindProxy(Object a) {
+int _kindProxy(Object arg0) {
   try {
-    return _kind!(a);
+    return _kind!(arg0);
   } catch (e) {
     _media_device_info__kind__set_error!(e);
     return 0;
   }
 }
 
-Pointer<Utf8> _labelProxy(Object a) {
+Pointer<Utf8> _labelProxy(Object arg0) {
   try {
-    return _label!(a);
+    return _label!(arg0);
   } catch (e) {
     _media_device_info__label__set_error!(e);
     return Pointer.fromAddress(0);
   }
 }
 
-Pointer _groupIdProxy(Object a) {
+Pointer _groupIdProxy(Object arg0) {
   try {
-    return _groupId!(a);
+    return _groupId!(arg0);
   } catch (e) {
     _media_device_info__group_id__set_error!(e);
     return Pointer.fromAddress(0);
   }
 }
 
-bool _isFailedProxy(Object a) {
+bool _isFailedProxy(Object arg0) {
   try {
-    return _isFailed!(a);
+    return _isFailed!(arg0);
   } catch (e) {
     _media_device_info__is_failed__set_error!(e);
     return false;

--- a/flutter/lib/src/native/platform/media_device_info.g.dart
+++ b/flutter/lib/src/native/platform/media_device_info.g.dart
@@ -4,22 +4,121 @@ import 'package:ffi/ffi.dart';
 
 import 'package:medea_jason/src/native/ffi/foreign_value.dart';
 
+typedef _ErrorSetterFnC = Void Function(Handle);
+typedef _ErrorSetterFnDart = void Function(Object);
+
+Pointer<Utf8> Function(Object)? _deviceId;
+int Function(Object)? _kind;
+Pointer<Utf8> Function(Object)? _label;
+Pointer Function(Object)? _groupId;
+bool Function(Object)? _isFailed;
+
+_ErrorSetterFnDart? _media_device_info__device_id__set_error;
+_ErrorSetterFnDart? _media_device_info__kind__set_error;
+_ErrorSetterFnDart? _media_device_info__label__set_error;
+_ErrorSetterFnDart? _media_device_info__group_id__set_error;
+_ErrorSetterFnDart? _media_device_info__is_failed__set_error;
+
 void registerFunction(
   DynamicLibrary dl, {
-  required Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> deviceId,
-  required Pointer<NativeFunction<Int64 Function(Handle)>> kind,
-  required Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> label,
-  required Pointer<NativeFunction<Pointer Function(Handle)>> groupId,
-  required Pointer<NativeFunction<Bool Function(Handle)>> isFailed,
+  required Pointer<Utf8> Function(Object) deviceId,
+  required int Function(Object) kind,
+  required Pointer<Utf8> Function(Object) label,
+  required Pointer Function(Object) groupId,
+  required bool Function(Object) isFailed,
 }) {
+  _deviceId = deviceId;
+  _kind = kind;
+  _label = label;
+  _groupId = groupId;
+  _isFailed = isFailed;
+
+  _media_device_info__device_id__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_device_info__device_id__set_error');
+  _media_device_info__kind__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_device_info__kind__set_error');
+  _media_device_info__label__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_device_info__label__set_error');
+  _media_device_info__group_id__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_device_info__group_id__set_error');
+  _media_device_info__is_failed__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_device_info__is_failed__set_error');
+
+  Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> deviceId_native =
+      Pointer.fromFunction(
+    _deviceIdProxy,
+  );
+  Pointer<NativeFunction<Int64 Function(Handle)>> kind_native =
+      Pointer.fromFunction(_kindProxy, 0);
+  Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> label_native =
+      Pointer.fromFunction(
+    _labelProxy,
+  );
+  Pointer<NativeFunction<Pointer Function(Handle)>> groupId_native =
+      Pointer.fromFunction(
+    _groupIdProxy,
+  );
+  Pointer<NativeFunction<Bool Function(Handle)>> isFailed_native =
+      Pointer.fromFunction(_isFailedProxy, false);
+
   dl.lookupFunction<
       Void Function(Pointer, Pointer, Pointer, Pointer, Pointer),
       void Function(Pointer, Pointer, Pointer, Pointer,
           Pointer)>('register_media_device_info')(
-    deviceId,
-    kind,
-    label,
-    groupId,
-    isFailed,
+    deviceId_native,
+    kind_native,
+    label_native,
+    groupId_native,
+    isFailed_native,
   );
+}
+
+Pointer<Utf8> _deviceIdProxy(Object a) {
+  try {
+    return _deviceId!(a);
+  } catch (e) {
+    _media_device_info__device_id__set_error!(e);
+    return Pointer.fromAddress(0);
+  }
+}
+
+int _kindProxy(Object a) {
+  try {
+    return _kind!(a);
+  } catch (e) {
+    _media_device_info__kind__set_error!(e);
+    return 0;
+  }
+}
+
+Pointer<Utf8> _labelProxy(Object a) {
+  try {
+    return _label!(a);
+  } catch (e) {
+    _media_device_info__label__set_error!(e);
+    return Pointer.fromAddress(0);
+  }
+}
+
+Pointer _groupIdProxy(Object a) {
+  try {
+    return _groupId!(a);
+  } catch (e) {
+    _media_device_info__group_id__set_error!(e);
+    return Pointer.fromAddress(0);
+  }
+}
+
+bool _isFailedProxy(Object a) {
+  try {
+    return _isFailed!(a);
+  } catch (e) {
+    _media_device_info__is_failed__set_error!(e);
+    return false;
+  }
 }

--- a/flutter/lib/src/native/platform/media_devices.dart
+++ b/flutter/lib/src/native/platform/media_devices.dart
@@ -2,7 +2,6 @@ import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';
 import 'package:medea_flutter_webrtc/medea_flutter_webrtc.dart' as webrtc;
-import 'package:medea_flutter_webrtc/src/platform/native/media_stream_track.dart';
 
 import 'package:medea_jason/src/native/ffi/native_string.dart';
 import 'media_devices.g.dart' as bridge;
@@ -72,7 +71,7 @@ class MockMediaDevices {
 }
 
 /// Requests media input access and returns the created [webrtc.MediaStreamTrack]s.
-Future<List<NativeMediaStreamTrack>> Function() _getUserMedia(
+Future<List<webrtc.MediaStreamTrack>> Function() _getUserMedia(
     Object constraints) {
   constraints as webrtc.DeviceConstraints;
   return () => webrtc.getUserMedia(constraints);
@@ -90,7 +89,7 @@ Future<List<webrtc.MediaDisplayInfo>> Function() _enumerateDisplays() {
 
 /// Starts capturing the contents of a display and returns the created
 /// [webrtc.MediaStreamTrack]s.
-Future<List<NativeMediaStreamTrack>> Function() _getDisplayMedia(
+Future<List<webrtc.MediaStreamTrack>> Function() _getDisplayMedia(
     Object constraints) {
   constraints as webrtc.DisplayConstraints;
   return () => webrtc.getDisplayMedia(constraints);

--- a/flutter/lib/src/native/platform/media_devices.dart
+++ b/flutter/lib/src/native/platform/media_devices.dart
@@ -2,6 +2,7 @@ import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';
 import 'package:medea_flutter_webrtc/medea_flutter_webrtc.dart' as webrtc;
+import 'package:medea_flutter_webrtc/src/platform/native/media_stream_track.dart';
 
 import 'package:medea_jason/src/native/ffi/native_string.dart';
 import 'media_devices.g.dart' as bridge;
@@ -14,32 +15,30 @@ void registerFunctions(DynamicLibrary dl) {
   if (mockable) {
     bridge.registerFunction(
       dl,
-      enumerateDevices: Pointer.fromFunction(_enumerateDevices),
-      enumerateDisplays: Pointer.fromFunction(_enumerateDisplays),
-      getUserMedia: Pointer.fromFunction(MockMediaDevices.getUserMedia),
-      getDisplayMedia: Pointer.fromFunction(_getDisplayMedia),
-      setOutputAudioId: Pointer.fromFunction(_setOutputAudioId),
-      setMicrophoneVolume: Pointer.fromFunction(_setMicrophoneVolume),
-      microphoneVolumeIsAvailable:
-          Pointer.fromFunction(_microphoneVolumeIsAvailable),
-      microphoneVolume: Pointer.fromFunction(_microphoneVolume),
-      onDeviceChange: Pointer.fromFunction(_onDeviceChange),
-      getMediaExceptionKind: Pointer.fromFunction(_getMediaExceptionKind, 0),
+      enumerateDevices: _enumerateDevices,
+      enumerateDisplays: _enumerateDisplays,
+      getUserMedia: MockMediaDevices.getUserMedia,
+      getDisplayMedia: _getDisplayMedia,
+      setOutputAudioId: _setOutputAudioId,
+      setMicrophoneVolume: _setMicrophoneVolume,
+      microphoneVolumeIsAvailable: _microphoneVolumeIsAvailable,
+      microphoneVolume: _microphoneVolume,
+      onDeviceChange: _onDeviceChange,
+      getMediaExceptionKind: _getMediaExceptionKind,
     );
   } else {
     bridge.registerFunction(
       dl,
-      enumerateDevices: Pointer.fromFunction(_enumerateDevices),
-      enumerateDisplays: Pointer.fromFunction(_enumerateDisplays),
-      getUserMedia: Pointer.fromFunction(_getUserMedia),
-      getDisplayMedia: Pointer.fromFunction(_getDisplayMedia),
-      setOutputAudioId: Pointer.fromFunction(_setOutputAudioId),
-      setMicrophoneVolume: Pointer.fromFunction(_setMicrophoneVolume),
-      microphoneVolumeIsAvailable:
-          Pointer.fromFunction(_microphoneVolumeIsAvailable),
-      microphoneVolume: Pointer.fromFunction(_microphoneVolume),
-      onDeviceChange: Pointer.fromFunction(_onDeviceChange),
-      getMediaExceptionKind: Pointer.fromFunction(_getMediaExceptionKind, 0),
+      enumerateDevices: _enumerateDevices,
+      enumerateDisplays: _enumerateDisplays,
+      getUserMedia: _getUserMedia,
+      getDisplayMedia: _getDisplayMedia,
+      setOutputAudioId: _setOutputAudioId,
+      setMicrophoneVolume: _setMicrophoneVolume,
+      microphoneVolumeIsAvailable: _microphoneVolumeIsAvailable,
+      microphoneVolume: _microphoneVolume,
+      onDeviceChange: _onDeviceChange,
+      getMediaExceptionKind: _getMediaExceptionKind,
     );
   }
 }
@@ -73,47 +72,49 @@ class MockMediaDevices {
 }
 
 /// Requests media input access and returns the created [webrtc.MediaStreamTrack]s.
-Object _getUserMedia(Object constraints) {
+Future<List<NativeMediaStreamTrack>> Function() _getUserMedia(
+    Object constraints) {
   constraints as webrtc.DeviceConstraints;
   return () => webrtc.getUserMedia(constraints);
 }
 
 /// Returns all the available media devices.
-Object _enumerateDevices() {
+Future<List<webrtc.MediaDeviceInfo>> Function() _enumerateDevices() {
   return () => webrtc.enumerateDevices();
 }
 
 /// Returns all the available media displays.
-Object _enumerateDisplays() {
+Future<List<webrtc.MediaDisplayInfo>> Function() _enumerateDisplays() {
   return () => webrtc.enumerateDisplays();
 }
 
 /// Starts capturing the contents of a display and returns the created
 /// [webrtc.MediaStreamTrack]s.
-Object _getDisplayMedia(Object constraints) {
+Future<List<NativeMediaStreamTrack>> Function() _getDisplayMedia(
+    Object constraints) {
   constraints as webrtc.DisplayConstraints;
   return () => webrtc.getDisplayMedia(constraints);
 }
 
 /// Switches output audio device to the device with the provided [deviceId].
-Object _setOutputAudioId(Pointer<Utf8> deviceId) {
+Future<void> Function() _setOutputAudioId(Pointer<Utf8> deviceId) {
   return () => webrtc.setOutputAudioId(deviceId.nativeStringToDartString());
 }
 
 /// Sets the microphone volume level in percents.
-Object _setMicrophoneVolume(int level) {
+Future<void> Function() _setMicrophoneVolume(int level) {
   return () => webrtc.setMicrophoneVolume(level);
 }
 
 /// Indicates whether it's possible to access microphone volume settings.
-Object _microphoneVolumeIsAvailable() {
+Future<int> Function() _microphoneVolumeIsAvailable() {
   return () async {
     return await webrtc.microphoneVolumeIsAvailable() ? 1 : 0;
   };
 }
 
 /// Gets the current microphone volume level in percents.
-Object _microphoneVolume() {
+Future<int> Function() _microphoneVolume() {
   return () => webrtc.microphoneVolume();
 }
 

--- a/flutter/lib/src/native/platform/media_devices.g.dart
+++ b/flutter/lib/src/native/platform/media_devices.g.dart
@@ -159,27 +159,27 @@ Object _enumerateDisplaysProxy() {
   }
 }
 
-Object _getUserMediaProxy(Object a) {
+Object _getUserMediaProxy(Object arg0) {
   try {
-    return _getUserMedia!(a);
+    return _getUserMedia!(arg0);
   } catch (e) {
     _media_devices__get_user_media__set_error!(e);
     return 0;
   }
 }
 
-Object _getDisplayMediaProxy(Object a) {
+Object _getDisplayMediaProxy(Object arg0) {
   try {
-    return _getDisplayMedia!(a);
+    return _getDisplayMedia!(arg0);
   } catch (e) {
     _media_devices__get_display_media__set_error!(e);
     return 0;
   }
 }
 
-Object _setOutputAudioIdProxy(Pointer<Utf8> a) {
+Object _setOutputAudioIdProxy(Pointer<Utf8> arg0) {
   try {
-    return _setOutputAudioId!(a);
+    return _setOutputAudioId!(arg0);
   } catch (e) {
     _media_devices__set_output_audio_id__set_error!(e);
     return 0;
@@ -204,27 +204,27 @@ Object _microphoneVolumeProxy() {
   }
 }
 
-Object _setMicrophoneVolumeProxy(int a) {
+Object _setMicrophoneVolumeProxy(int arg0) {
   try {
-    return _setMicrophoneVolume!(a);
+    return _setMicrophoneVolume!(arg0);
   } catch (e) {
     _media_devices__set_microphone_volume__set_error!(e);
     return 0;
   }
 }
 
-void _onDeviceChangeProxy(Object a) {
+void _onDeviceChangeProxy(Object arg0) {
   try {
-    return _onDeviceChange!(a);
+    return _onDeviceChange!(arg0);
   } catch (e) {
     _media_devices__on_device_change__set_error!(e);
     return;
   }
 }
 
-int _getMediaExceptionKindProxy(Object a) {
+int _getMediaExceptionKindProxy(Object arg0) {
   try {
-    return _getMediaExceptionKind!(a);
+    return _getMediaExceptionKind!(arg0);
   } catch (e) {
     _media_devices__get_media_exception_kind__set_error!(e);
     return 0;

--- a/flutter/lib/src/native/platform/media_devices.g.dart
+++ b/flutter/lib/src/native/platform/media_devices.g.dart
@@ -4,36 +4,229 @@ import 'package:ffi/ffi.dart';
 
 import 'package:medea_jason/src/native/ffi/foreign_value.dart';
 
+typedef _ErrorSetterFnC = Void Function(Handle);
+typedef _ErrorSetterFnDart = void Function(Object);
+
+Object Function()? _enumerateDevices;
+Object Function()? _enumerateDisplays;
+Object Function(Object)? _getUserMedia;
+Object Function(Object)? _getDisplayMedia;
+Object Function(Pointer<Utf8>)? _setOutputAudioId;
+Object Function()? _microphoneVolumeIsAvailable;
+Object Function()? _microphoneVolume;
+Object Function(int)? _setMicrophoneVolume;
+void Function(Object)? _onDeviceChange;
+int Function(Object)? _getMediaExceptionKind;
+
+_ErrorSetterFnDart? _media_devices__enumerate_devices__set_error;
+_ErrorSetterFnDart? _media_devices__enumerate_displays__set_error;
+_ErrorSetterFnDart? _media_devices__get_user_media__set_error;
+_ErrorSetterFnDart? _media_devices__get_display_media__set_error;
+_ErrorSetterFnDart? _media_devices__set_output_audio_id__set_error;
+_ErrorSetterFnDart? _media_devices__microphone_volume_is_available__set_error;
+_ErrorSetterFnDart? _media_devices__microphone_volume__set_error;
+_ErrorSetterFnDart? _media_devices__set_microphone_volume__set_error;
+_ErrorSetterFnDart? _media_devices__on_device_change__set_error;
+_ErrorSetterFnDart? _media_devices__get_media_exception_kind__set_error;
+
 void registerFunction(
   DynamicLibrary dl, {
-  required Pointer<NativeFunction<Handle Function()>> enumerateDevices,
-  required Pointer<NativeFunction<Handle Function()>> enumerateDisplays,
-  required Pointer<NativeFunction<Handle Function(Handle)>> getUserMedia,
-  required Pointer<NativeFunction<Handle Function(Handle)>> getDisplayMedia,
-  required Pointer<NativeFunction<Handle Function(Pointer<Utf8>)>>
-      setOutputAudioId,
-  required Pointer<NativeFunction<Handle Function()>>
-      microphoneVolumeIsAvailable,
-  required Pointer<NativeFunction<Handle Function()>> microphoneVolume,
-  required Pointer<NativeFunction<Handle Function(Int64)>> setMicrophoneVolume,
-  required Pointer<NativeFunction<Void Function(Handle)>> onDeviceChange,
-  required Pointer<NativeFunction<Int64 Function(Handle)>>
-      getMediaExceptionKind,
+  required Object Function() enumerateDevices,
+  required Object Function() enumerateDisplays,
+  required Object Function(Object) getUserMedia,
+  required Object Function(Object) getDisplayMedia,
+  required Object Function(Pointer<Utf8>) setOutputAudioId,
+  required Object Function() microphoneVolumeIsAvailable,
+  required Object Function() microphoneVolume,
+  required Object Function(int) setMicrophoneVolume,
+  required void Function(Object) onDeviceChange,
+  required int Function(Object) getMediaExceptionKind,
 }) {
+  _enumerateDevices = enumerateDevices;
+  _enumerateDisplays = enumerateDisplays;
+  _getUserMedia = getUserMedia;
+  _getDisplayMedia = getDisplayMedia;
+  _setOutputAudioId = setOutputAudioId;
+  _microphoneVolumeIsAvailable = microphoneVolumeIsAvailable;
+  _microphoneVolume = microphoneVolume;
+  _setMicrophoneVolume = setMicrophoneVolume;
+  _onDeviceChange = onDeviceChange;
+  _getMediaExceptionKind = getMediaExceptionKind;
+
+  _media_devices__enumerate_devices__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_devices__enumerate_devices__set_error');
+  _media_devices__enumerate_displays__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_devices__enumerate_displays__set_error');
+  _media_devices__get_user_media__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_devices__get_user_media__set_error');
+  _media_devices__get_display_media__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_devices__get_display_media__set_error');
+  _media_devices__set_output_audio_id__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_devices__set_output_audio_id__set_error');
+  _media_devices__microphone_volume_is_available__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_devices__microphone_volume_is_available__set_error');
+  _media_devices__microphone_volume__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_devices__microphone_volume__set_error');
+  _media_devices__set_microphone_volume__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_devices__set_microphone_volume__set_error');
+  _media_devices__on_device_change__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_devices__on_device_change__set_error');
+  _media_devices__get_media_exception_kind__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_devices__get_media_exception_kind__set_error');
+
+  Pointer<NativeFunction<Handle Function()>> enumerateDevices_native =
+      Pointer.fromFunction(
+    _enumerateDevicesProxy,
+  );
+  Pointer<NativeFunction<Handle Function()>> enumerateDisplays_native =
+      Pointer.fromFunction(
+    _enumerateDisplaysProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Handle)>> getUserMedia_native =
+      Pointer.fromFunction(
+    _getUserMediaProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Handle)>> getDisplayMedia_native =
+      Pointer.fromFunction(
+    _getDisplayMediaProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Pointer<Utf8>)>>
+      setOutputAudioId_native = Pointer.fromFunction(
+    _setOutputAudioIdProxy,
+  );
+  Pointer<NativeFunction<Handle Function()>>
+      microphoneVolumeIsAvailable_native = Pointer.fromFunction(
+    _microphoneVolumeIsAvailableProxy,
+  );
+  Pointer<NativeFunction<Handle Function()>> microphoneVolume_native =
+      Pointer.fromFunction(
+    _microphoneVolumeProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Int64)>> setMicrophoneVolume_native =
+      Pointer.fromFunction(
+    _setMicrophoneVolumeProxy,
+  );
+  Pointer<NativeFunction<Void Function(Handle)>> onDeviceChange_native =
+      Pointer.fromFunction(
+    _onDeviceChangeProxy,
+  );
+  Pointer<NativeFunction<Int64 Function(Handle)>> getMediaExceptionKind_native =
+      Pointer.fromFunction(_getMediaExceptionKindProxy, 0);
+
   dl.lookupFunction<
       Void Function(Pointer, Pointer, Pointer, Pointer, Pointer, Pointer,
           Pointer, Pointer, Pointer, Pointer),
       void Function(Pointer, Pointer, Pointer, Pointer, Pointer, Pointer,
           Pointer, Pointer, Pointer, Pointer)>('register_media_devices')(
-    enumerateDevices,
-    enumerateDisplays,
-    getUserMedia,
-    getDisplayMedia,
-    setOutputAudioId,
-    microphoneVolumeIsAvailable,
-    microphoneVolume,
-    setMicrophoneVolume,
-    onDeviceChange,
-    getMediaExceptionKind,
+    enumerateDevices_native,
+    enumerateDisplays_native,
+    getUserMedia_native,
+    getDisplayMedia_native,
+    setOutputAudioId_native,
+    microphoneVolumeIsAvailable_native,
+    microphoneVolume_native,
+    setMicrophoneVolume_native,
+    onDeviceChange_native,
+    getMediaExceptionKind_native,
   );
+}
+
+Object _enumerateDevicesProxy() {
+  try {
+    return _enumerateDevices!();
+  } catch (e) {
+    _media_devices__enumerate_devices__set_error!(e);
+    return 0;
+  }
+}
+
+Object _enumerateDisplaysProxy() {
+  try {
+    return _enumerateDisplays!();
+  } catch (e) {
+    _media_devices__enumerate_displays__set_error!(e);
+    return 0;
+  }
+}
+
+Object _getUserMediaProxy(Object a) {
+  try {
+    return _getUserMedia!(a);
+  } catch (e) {
+    _media_devices__get_user_media__set_error!(e);
+    return 0;
+  }
+}
+
+Object _getDisplayMediaProxy(Object a) {
+  try {
+    return _getDisplayMedia!(a);
+  } catch (e) {
+    _media_devices__get_display_media__set_error!(e);
+    return 0;
+  }
+}
+
+Object _setOutputAudioIdProxy(Pointer<Utf8> a) {
+  try {
+    return _setOutputAudioId!(a);
+  } catch (e) {
+    _media_devices__set_output_audio_id__set_error!(e);
+    return 0;
+  }
+}
+
+Object _microphoneVolumeIsAvailableProxy() {
+  try {
+    return _microphoneVolumeIsAvailable!();
+  } catch (e) {
+    _media_devices__microphone_volume_is_available__set_error!(e);
+    return 0;
+  }
+}
+
+Object _microphoneVolumeProxy() {
+  try {
+    return _microphoneVolume!();
+  } catch (e) {
+    _media_devices__microphone_volume__set_error!(e);
+    return 0;
+  }
+}
+
+Object _setMicrophoneVolumeProxy(int a) {
+  try {
+    return _setMicrophoneVolume!(a);
+  } catch (e) {
+    _media_devices__set_microphone_volume__set_error!(e);
+    return 0;
+  }
+}
+
+void _onDeviceChangeProxy(Object a) {
+  try {
+    return _onDeviceChange!(a);
+  } catch (e) {
+    _media_devices__on_device_change__set_error!(e);
+    return;
+  }
+}
+
+int _getMediaExceptionKindProxy(Object a) {
+  try {
+    return _getMediaExceptionKind!(a);
+  } catch (e) {
+    _media_devices__get_media_exception_kind__set_error!(e);
+    return 0;
+  }
 }

--- a/flutter/lib/src/native/platform/media_display_info.dart
+++ b/flutter/lib/src/native/platform/media_display_info.dart
@@ -10,8 +10,8 @@ import 'media_display_info.g.dart' as bridge;
 void registerFunctions(DynamicLibrary dl) {
   bridge.registerFunction(
     dl,
-    deviceId: Pointer.fromFunction(_deviceId),
-    title: Pointer.fromFunction(_title),
+    deviceId: _deviceId,
+    title: _title,
   );
 }
 

--- a/flutter/lib/src/native/platform/media_display_info.g.dart
+++ b/flutter/lib/src/native/platform/media_display_info.g.dart
@@ -44,18 +44,18 @@ void registerFunction(
   );
 }
 
-Pointer<Utf8> _deviceIdProxy(Object a) {
+Pointer<Utf8> _deviceIdProxy(Object arg0) {
   try {
-    return _deviceId!(a);
+    return _deviceId!(arg0);
   } catch (e) {
     _media_display_info__device_id__set_error!(e);
     return Pointer.fromAddress(0);
   }
 }
 
-Pointer _titleProxy(Object a) {
+Pointer _titleProxy(Object arg0) {
   try {
-    return _title!(a);
+    return _title!(arg0);
   } catch (e) {
     _media_display_info__title__set_error!(e);
     return Pointer.fromAddress(0);

--- a/flutter/lib/src/native/platform/media_display_info.g.dart
+++ b/flutter/lib/src/native/platform/media_display_info.g.dart
@@ -4,14 +4,60 @@ import 'package:ffi/ffi.dart';
 
 import 'package:medea_jason/src/native/ffi/foreign_value.dart';
 
+typedef _ErrorSetterFnC = Void Function(Handle);
+typedef _ErrorSetterFnDart = void Function(Object);
+
+Pointer<Utf8> Function(Object)? _deviceId;
+Pointer Function(Object)? _title;
+
+_ErrorSetterFnDart? _media_display_info__device_id__set_error;
+_ErrorSetterFnDart? _media_display_info__title__set_error;
+
 void registerFunction(
   DynamicLibrary dl, {
-  required Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> deviceId,
-  required Pointer<NativeFunction<Pointer Function(Handle)>> title,
+  required Pointer<Utf8> Function(Object) deviceId,
+  required Pointer Function(Object) title,
 }) {
+  _deviceId = deviceId;
+  _title = title;
+
+  _media_display_info__device_id__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_display_info__device_id__set_error');
+  _media_display_info__title__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_display_info__title__set_error');
+
+  Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> deviceId_native =
+      Pointer.fromFunction(
+    _deviceIdProxy,
+  );
+  Pointer<NativeFunction<Pointer Function(Handle)>> title_native =
+      Pointer.fromFunction(
+    _titleProxy,
+  );
+
   dl.lookupFunction<Void Function(Pointer, Pointer),
       void Function(Pointer, Pointer)>('register_media_display_info')(
-    deviceId,
-    title,
+    deviceId_native,
+    title_native,
   );
+}
+
+Pointer<Utf8> _deviceIdProxy(Object a) {
+  try {
+    return _deviceId!(a);
+  } catch (e) {
+    _media_display_info__device_id__set_error!(e);
+    return Pointer.fromAddress(0);
+  }
+}
+
+Pointer _titleProxy(Object a) {
+  try {
+    return _title!(a);
+  } catch (e) {
+    _media_display_info__title__set_error!(e);
+    return Pointer.fromAddress(0);
+  }
 }

--- a/flutter/lib/src/native/platform/media_track.dart
+++ b/flutter/lib/src/native/platform/media_track.dart
@@ -10,22 +10,21 @@ import 'media_track.g.dart' as bridge;
 void registerFunctions(DynamicLibrary dl) {
   bridge.registerFunction(
     dl,
-    id: Pointer.fromFunction(_id),
-    deviceId: Pointer.fromFunction(_deviceId),
-    facingMode: Pointer.fromFunction(_facingMode),
-    kind: Pointer.fromFunction(_kind, 0),
-    height: Pointer.fromFunction(_height),
-    width: Pointer.fromFunction(_width),
-    setEnabled: Pointer.fromFunction(_setEnabled),
-    enabled: Pointer.fromFunction(_enabled, false),
-    stop: Pointer.fromFunction(_stop),
-    onEnded: Pointer.fromFunction(_onEnded),
-    clone: Pointer.fromFunction(_clone),
-    readyState: Pointer.fromFunction(_readyState),
-    dispose: Pointer.fromFunction(_dispose),
-    onAudioLevelChanged: Pointer.fromFunction(_onAudioLevelChanged),
-    isOnAudioLevelAvailable:
-        Pointer.fromFunction(_isOnAudioLevelAvailable, false),
+    id: _id,
+    deviceId: _deviceId,
+    facingMode: _facingMode,
+    kind: _kind,
+    height: _height,
+    width: _width,
+    setEnabled: _setEnabled,
+    enabled: _enabled,
+    stop: _stop,
+    onEnded: _onEnded,
+    clone: _clone,
+    readyState: _readyState,
+    dispose: _dispose,
+    onAudioLevelChanged: _onAudioLevelChanged,
+    isOnAudioLevelAvailable: _isOnAudioLevelAvailable,
   );
 }
 
@@ -62,7 +61,7 @@ Pointer<Utf8> _deviceId(Object track) {
   return track.deviceId().toNativeUtf8();
 }
 
-Object _readyState(Object track) {
+Future<int> Function() _readyState(Object track) {
   track as MediaStreamTrack;
   return () => track.state().then((s) => s.index);
 }
@@ -95,7 +94,7 @@ void _setEnabled(Object track, bool enabled) {
 }
 
 /// Stops the provided [MediaStreamTrack].
-Object _stop(Object track) {
+Future<void> Function() _stop(Object track) {
   track as MediaStreamTrack;
   return () => track.stop();
 }
@@ -125,13 +124,13 @@ bool _enabled(Object track) {
 }
 
 /// Clones the provided [MediaStreamTrack] preserving the same media source.
-Object _clone(Object track) {
+Future<MediaStreamTrack> Function() _clone(Object track) {
   track as MediaStreamTrack;
   return () => track.clone();
 }
 
 /// Disposes of this [MediaStreamTrack].
-Object _dispose(Object track) {
+Future<void> Function() _dispose(Object track) {
   track as MediaStreamTrack;
   return () => track.dispose();
 }

--- a/flutter/lib/src/native/platform/media_track.g.dart
+++ b/flutter/lib/src/native/platform/media_track.g.dart
@@ -226,135 +226,135 @@ void registerFunction(
   );
 }
 
-Pointer<Utf8> _idProxy(Object a) {
+Pointer<Utf8> _idProxy(Object arg0) {
   try {
-    return _id!(a);
+    return _id!(arg0);
   } catch (e) {
     _media_stream_track__id__set_error!(e);
     return Pointer.fromAddress(0);
   }
 }
 
-Pointer<Utf8> _deviceIdProxy(Object a) {
+Pointer<Utf8> _deviceIdProxy(Object arg0) {
   try {
-    return _deviceId!(a);
+    return _deviceId!(arg0);
   } catch (e) {
     _media_stream_track__device_id__set_error!(e);
     return Pointer.fromAddress(0);
   }
 }
 
-int _kindProxy(Object a) {
+int _kindProxy(Object arg0) {
   try {
-    return _kind!(a);
+    return _kind!(arg0);
   } catch (e) {
     _media_stream_track__kind__set_error!(e);
     return 0;
   }
 }
 
-Pointer _facingModeProxy(Object a) {
+Pointer _facingModeProxy(Object arg0) {
   try {
-    return _facingMode!(a);
+    return _facingMode!(arg0);
   } catch (e) {
     _media_stream_track__facing_mode__set_error!(e);
     return Pointer.fromAddress(0);
   }
 }
 
-Pointer _heightProxy(Object a) {
+Pointer _heightProxy(Object arg0) {
   try {
-    return _height!(a);
+    return _height!(arg0);
   } catch (e) {
     _media_stream_track__height__set_error!(e);
     return Pointer.fromAddress(0);
   }
 }
 
-Pointer _widthProxy(Object a) {
+Pointer _widthProxy(Object arg0) {
   try {
-    return _width!(a);
+    return _width!(arg0);
   } catch (e) {
     _media_stream_track__width__set_error!(e);
     return Pointer.fromAddress(0);
   }
 }
 
-bool _enabledProxy(Object a) {
+bool _enabledProxy(Object arg0) {
   try {
-    return _enabled!(a);
+    return _enabled!(arg0);
   } catch (e) {
     _media_stream_track__enabled__set_error!(e);
     return false;
   }
 }
 
-void _setEnabledProxy(Object a, bool b) {
+void _setEnabledProxy(Object arg0, bool arg1) {
   try {
-    return _setEnabled!(a, b);
+    return _setEnabled!(arg0, arg1);
   } catch (e) {
     _media_stream_track__set_enabled__set_error!(e);
     return;
   }
 }
 
-Object _readyStateProxy(Object a) {
+Object _readyStateProxy(Object arg0) {
   try {
-    return _readyState!(a);
+    return _readyState!(arg0);
   } catch (e) {
     _media_stream_track__ready_state__set_error!(e);
     return 0;
   }
 }
 
-Object _stopProxy(Object a) {
+Object _stopProxy(Object arg0) {
   try {
-    return _stop!(a);
+    return _stop!(arg0);
   } catch (e) {
     _media_stream_track__stop__set_error!(e);
     return 0;
   }
 }
 
-void _onEndedProxy(Object a, Object b) {
+void _onEndedProxy(Object arg0, Object arg1) {
   try {
-    return _onEnded!(a, b);
+    return _onEnded!(arg0, arg1);
   } catch (e) {
     _media_stream_track__on_ended__set_error!(e);
     return;
   }
 }
 
-Object _cloneProxy(Object a) {
+Object _cloneProxy(Object arg0) {
   try {
-    return _clone!(a);
+    return _clone!(arg0);
   } catch (e) {
     _media_stream_track__clone__set_error!(e);
     return 0;
   }
 }
 
-Object _disposeProxy(Object a) {
+Object _disposeProxy(Object arg0) {
   try {
-    return _dispose!(a);
+    return _dispose!(arg0);
   } catch (e) {
     _media_stream_track__dispose__set_error!(e);
     return 0;
   }
 }
 
-bool _isOnAudioLevelAvailableProxy(Object a) {
+bool _isOnAudioLevelAvailableProxy(Object arg0) {
   try {
-    return _isOnAudioLevelAvailable!(a);
+    return _isOnAudioLevelAvailable!(arg0);
   } catch (e) {
     _media_stream_track__is_on_audio_level_available__set_error!(e);
     return false;
   }
 }
 
-void _onAudioLevelChangedProxy(Object a, Object b) {
+void _onAudioLevelChangedProxy(Object arg0, Object arg1) {
   try {
-    return _onAudioLevelChanged!(a, b);
+    return _onAudioLevelChanged!(arg0, arg1);
   } catch (e) {
     _media_stream_track__on_audio_level_changed__set_error!(e);
     return;

--- a/flutter/lib/src/native/platform/media_track.g.dart
+++ b/flutter/lib/src/native/platform/media_track.g.dart
@@ -4,26 +4,177 @@ import 'package:ffi/ffi.dart';
 
 import 'package:medea_jason/src/native/ffi/foreign_value.dart';
 
+typedef _ErrorSetterFnC = Void Function(Handle);
+typedef _ErrorSetterFnDart = void Function(Object);
+
+Pointer<Utf8> Function(Object)? _id;
+Pointer<Utf8> Function(Object)? _deviceId;
+int Function(Object)? _kind;
+Pointer Function(Object)? _facingMode;
+Pointer Function(Object)? _height;
+Pointer Function(Object)? _width;
+bool Function(Object)? _enabled;
+void Function(Object, bool)? _setEnabled;
+Object Function(Object)? _readyState;
+Object Function(Object)? _stop;
+void Function(Object, Object)? _onEnded;
+Object Function(Object)? _clone;
+Object Function(Object)? _dispose;
+bool Function(Object)? _isOnAudioLevelAvailable;
+void Function(Object, Object)? _onAudioLevelChanged;
+
+_ErrorSetterFnDart? _media_stream_track__id__set_error;
+_ErrorSetterFnDart? _media_stream_track__device_id__set_error;
+_ErrorSetterFnDart? _media_stream_track__kind__set_error;
+_ErrorSetterFnDart? _media_stream_track__facing_mode__set_error;
+_ErrorSetterFnDart? _media_stream_track__height__set_error;
+_ErrorSetterFnDart? _media_stream_track__width__set_error;
+_ErrorSetterFnDart? _media_stream_track__enabled__set_error;
+_ErrorSetterFnDart? _media_stream_track__set_enabled__set_error;
+_ErrorSetterFnDart? _media_stream_track__ready_state__set_error;
+_ErrorSetterFnDart? _media_stream_track__stop__set_error;
+_ErrorSetterFnDart? _media_stream_track__on_ended__set_error;
+_ErrorSetterFnDart? _media_stream_track__clone__set_error;
+_ErrorSetterFnDart? _media_stream_track__dispose__set_error;
+_ErrorSetterFnDart? _media_stream_track__is_on_audio_level_available__set_error;
+_ErrorSetterFnDart? _media_stream_track__on_audio_level_changed__set_error;
+
 void registerFunction(
   DynamicLibrary dl, {
-  required Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> id,
-  required Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> deviceId,
-  required Pointer<NativeFunction<Int64 Function(Handle)>> kind,
-  required Pointer<NativeFunction<Pointer Function(Handle)>> facingMode,
-  required Pointer<NativeFunction<Pointer Function(Handle)>> height,
-  required Pointer<NativeFunction<Pointer Function(Handle)>> width,
-  required Pointer<NativeFunction<Bool Function(Handle)>> enabled,
-  required Pointer<NativeFunction<Void Function(Handle, Bool)>> setEnabled,
-  required Pointer<NativeFunction<Handle Function(Handle)>> readyState,
-  required Pointer<NativeFunction<Handle Function(Handle)>> stop,
-  required Pointer<NativeFunction<Void Function(Handle, Handle)>> onEnded,
-  required Pointer<NativeFunction<Handle Function(Handle)>> clone,
-  required Pointer<NativeFunction<Handle Function(Handle)>> dispose,
-  required Pointer<NativeFunction<Bool Function(Handle)>>
-      isOnAudioLevelAvailable,
-  required Pointer<NativeFunction<Void Function(Handle, Handle)>>
-      onAudioLevelChanged,
+  required Pointer<Utf8> Function(Object) id,
+  required Pointer<Utf8> Function(Object) deviceId,
+  required int Function(Object) kind,
+  required Pointer Function(Object) facingMode,
+  required Pointer Function(Object) height,
+  required Pointer Function(Object) width,
+  required bool Function(Object) enabled,
+  required void Function(Object, bool) setEnabled,
+  required Object Function(Object) readyState,
+  required Object Function(Object) stop,
+  required void Function(Object, Object) onEnded,
+  required Object Function(Object) clone,
+  required Object Function(Object) dispose,
+  required bool Function(Object) isOnAudioLevelAvailable,
+  required void Function(Object, Object) onAudioLevelChanged,
 }) {
+  _id = id;
+  _deviceId = deviceId;
+  _kind = kind;
+  _facingMode = facingMode;
+  _height = height;
+  _width = width;
+  _enabled = enabled;
+  _setEnabled = setEnabled;
+  _readyState = readyState;
+  _stop = stop;
+  _onEnded = onEnded;
+  _clone = clone;
+  _dispose = dispose;
+  _isOnAudioLevelAvailable = isOnAudioLevelAvailable;
+  _onAudioLevelChanged = onAudioLevelChanged;
+
+  _media_stream_track__id__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_stream_track__id__set_error');
+  _media_stream_track__device_id__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_stream_track__device_id__set_error');
+  _media_stream_track__kind__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_stream_track__kind__set_error');
+  _media_stream_track__facing_mode__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_stream_track__facing_mode__set_error');
+  _media_stream_track__height__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_stream_track__height__set_error');
+  _media_stream_track__width__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_stream_track__width__set_error');
+  _media_stream_track__enabled__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_stream_track__enabled__set_error');
+  _media_stream_track__set_enabled__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_stream_track__set_enabled__set_error');
+  _media_stream_track__ready_state__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_stream_track__ready_state__set_error');
+  _media_stream_track__stop__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_stream_track__stop__set_error');
+  _media_stream_track__on_ended__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_stream_track__on_ended__set_error');
+  _media_stream_track__clone__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_stream_track__clone__set_error');
+  _media_stream_track__dispose__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_stream_track__dispose__set_error');
+  _media_stream_track__is_on_audio_level_available__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_stream_track__is_on_audio_level_available__set_error');
+  _media_stream_track__on_audio_level_changed__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'media_stream_track__on_audio_level_changed__set_error');
+
+  Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> id_native =
+      Pointer.fromFunction(
+    _idProxy,
+  );
+  Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> deviceId_native =
+      Pointer.fromFunction(
+    _deviceIdProxy,
+  );
+  Pointer<NativeFunction<Int64 Function(Handle)>> kind_native =
+      Pointer.fromFunction(_kindProxy, 0);
+  Pointer<NativeFunction<Pointer Function(Handle)>> facingMode_native =
+      Pointer.fromFunction(
+    _facingModeProxy,
+  );
+  Pointer<NativeFunction<Pointer Function(Handle)>> height_native =
+      Pointer.fromFunction(
+    _heightProxy,
+  );
+  Pointer<NativeFunction<Pointer Function(Handle)>> width_native =
+      Pointer.fromFunction(
+    _widthProxy,
+  );
+  Pointer<NativeFunction<Bool Function(Handle)>> enabled_native =
+      Pointer.fromFunction(_enabledProxy, false);
+  Pointer<NativeFunction<Void Function(Handle, Bool)>> setEnabled_native =
+      Pointer.fromFunction(
+    _setEnabledProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Handle)>> readyState_native =
+      Pointer.fromFunction(
+    _readyStateProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Handle)>> stop_native =
+      Pointer.fromFunction(
+    _stopProxy,
+  );
+  Pointer<NativeFunction<Void Function(Handle, Handle)>> onEnded_native =
+      Pointer.fromFunction(
+    _onEndedProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Handle)>> clone_native =
+      Pointer.fromFunction(
+    _cloneProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Handle)>> dispose_native =
+      Pointer.fromFunction(
+    _disposeProxy,
+  );
+  Pointer<NativeFunction<Bool Function(Handle)>>
+      isOnAudioLevelAvailable_native =
+      Pointer.fromFunction(_isOnAudioLevelAvailableProxy, false);
+  Pointer<NativeFunction<Void Function(Handle, Handle)>>
+      onAudioLevelChanged_native = Pointer.fromFunction(
+    _onAudioLevelChangedProxy,
+  );
+
   dl.lookupFunction<
       Void Function(
           Pointer,
@@ -57,20 +208,155 @@ void registerFunction(
           Pointer,
           Pointer,
           Pointer)>('register_media_stream_track')(
-    id,
-    deviceId,
-    kind,
-    facingMode,
-    height,
-    width,
-    enabled,
-    setEnabled,
-    readyState,
-    stop,
-    onEnded,
-    clone,
-    dispose,
-    isOnAudioLevelAvailable,
-    onAudioLevelChanged,
+    id_native,
+    deviceId_native,
+    kind_native,
+    facingMode_native,
+    height_native,
+    width_native,
+    enabled_native,
+    setEnabled_native,
+    readyState_native,
+    stop_native,
+    onEnded_native,
+    clone_native,
+    dispose_native,
+    isOnAudioLevelAvailable_native,
+    onAudioLevelChanged_native,
   );
+}
+
+Pointer<Utf8> _idProxy(Object a) {
+  try {
+    return _id!(a);
+  } catch (e) {
+    _media_stream_track__id__set_error!(e);
+    return Pointer.fromAddress(0);
+  }
+}
+
+Pointer<Utf8> _deviceIdProxy(Object a) {
+  try {
+    return _deviceId!(a);
+  } catch (e) {
+    _media_stream_track__device_id__set_error!(e);
+    return Pointer.fromAddress(0);
+  }
+}
+
+int _kindProxy(Object a) {
+  try {
+    return _kind!(a);
+  } catch (e) {
+    _media_stream_track__kind__set_error!(e);
+    return 0;
+  }
+}
+
+Pointer _facingModeProxy(Object a) {
+  try {
+    return _facingMode!(a);
+  } catch (e) {
+    _media_stream_track__facing_mode__set_error!(e);
+    return Pointer.fromAddress(0);
+  }
+}
+
+Pointer _heightProxy(Object a) {
+  try {
+    return _height!(a);
+  } catch (e) {
+    _media_stream_track__height__set_error!(e);
+    return Pointer.fromAddress(0);
+  }
+}
+
+Pointer _widthProxy(Object a) {
+  try {
+    return _width!(a);
+  } catch (e) {
+    _media_stream_track__width__set_error!(e);
+    return Pointer.fromAddress(0);
+  }
+}
+
+bool _enabledProxy(Object a) {
+  try {
+    return _enabled!(a);
+  } catch (e) {
+    _media_stream_track__enabled__set_error!(e);
+    return false;
+  }
+}
+
+void _setEnabledProxy(Object a, bool b) {
+  try {
+    return _setEnabled!(a, b);
+  } catch (e) {
+    _media_stream_track__set_enabled__set_error!(e);
+    return;
+  }
+}
+
+Object _readyStateProxy(Object a) {
+  try {
+    return _readyState!(a);
+  } catch (e) {
+    _media_stream_track__ready_state__set_error!(e);
+    return 0;
+  }
+}
+
+Object _stopProxy(Object a) {
+  try {
+    return _stop!(a);
+  } catch (e) {
+    _media_stream_track__stop__set_error!(e);
+    return 0;
+  }
+}
+
+void _onEndedProxy(Object a, Object b) {
+  try {
+    return _onEnded!(a, b);
+  } catch (e) {
+    _media_stream_track__on_ended__set_error!(e);
+    return;
+  }
+}
+
+Object _cloneProxy(Object a) {
+  try {
+    return _clone!(a);
+  } catch (e) {
+    _media_stream_track__clone__set_error!(e);
+    return 0;
+  }
+}
+
+Object _disposeProxy(Object a) {
+  try {
+    return _dispose!(a);
+  } catch (e) {
+    _media_stream_track__dispose__set_error!(e);
+    return 0;
+  }
+}
+
+bool _isOnAudioLevelAvailableProxy(Object a) {
+  try {
+    return _isOnAudioLevelAvailable!(a);
+  } catch (e) {
+    _media_stream_track__is_on_audio_level_available__set_error!(e);
+    return false;
+  }
+}
+
+void _onAudioLevelChangedProxy(Object a, Object b) {
+  try {
+    return _onAudioLevelChanged!(a, b);
+  } catch (e) {
+    _media_stream_track__on_audio_level_changed__set_error!(e);
+    return;
+  }
 }

--- a/flutter/lib/src/native/platform/object.dart
+++ b/flutter/lib/src/native/platform/object.dart
@@ -8,8 +8,8 @@ import 'object.g.dart' as bridge;
 void registerFunctions(DynamicLibrary dl) {
   bridge.registerFunction(
     dl,
-    runtimeType: Pointer.fromFunction(_runtimeType),
-    toString: Pointer.fromFunction(_toString),
+    runtimeType: _runtimeType,
+    toString: _toString,
   );
 }
 

--- a/flutter/lib/src/native/platform/object.g.dart
+++ b/flutter/lib/src/native/platform/object.g.dart
@@ -4,14 +4,60 @@ import 'package:ffi/ffi.dart';
 
 import 'package:medea_jason/src/native/ffi/foreign_value.dart';
 
+typedef _ErrorSetterFnC = Void Function(Handle);
+typedef _ErrorSetterFnDart = void Function(Object);
+
+Pointer<Utf8> Function(Object)? _runtimeType;
+Pointer<Utf8> Function(Object)? _toString;
+
+_ErrorSetterFnDart? _handle__runtime_type__set_error;
+_ErrorSetterFnDart? _handle__to_string__set_error;
+
 void registerFunction(
   DynamicLibrary dl, {
-  required Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> runtimeType,
-  required Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> toString,
+  required Pointer<Utf8> Function(Object) runtimeType,
+  required Pointer<Utf8> Function(Object) toString,
 }) {
+  _runtimeType = runtimeType;
+  _toString = toString;
+
+  _handle__runtime_type__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'handle__runtime_type__set_error');
+  _handle__to_string__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'handle__to_string__set_error');
+
+  Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> runtimeType_native =
+      Pointer.fromFunction(
+    _runtimeTypeProxy,
+  );
+  Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> toString_native =
+      Pointer.fromFunction(
+    _toStringProxy,
+  );
+
   dl.lookupFunction<Void Function(Pointer, Pointer),
       void Function(Pointer, Pointer)>('register_handle')(
-    runtimeType,
-    toString,
+    runtimeType_native,
+    toString_native,
   );
+}
+
+Pointer<Utf8> _runtimeTypeProxy(Object a) {
+  try {
+    return _runtimeType!(a);
+  } catch (e) {
+    _handle__runtime_type__set_error!(e);
+    return Pointer.fromAddress(0);
+  }
+}
+
+Pointer<Utf8> _toStringProxy(Object a) {
+  try {
+    return _toString!(a);
+  } catch (e) {
+    _handle__to_string__set_error!(e);
+    return Pointer.fromAddress(0);
+  }
 }

--- a/flutter/lib/src/native/platform/object.g.dart
+++ b/flutter/lib/src/native/platform/object.g.dart
@@ -44,18 +44,18 @@ void registerFunction(
   );
 }
 
-Pointer<Utf8> _runtimeTypeProxy(Object a) {
+Pointer<Utf8> _runtimeTypeProxy(Object arg0) {
   try {
-    return _runtimeType!(a);
+    return _runtimeType!(arg0);
   } catch (e) {
     _handle__runtime_type__set_error!(e);
     return Pointer.fromAddress(0);
   }
 }
 
-Pointer<Utf8> _toStringProxy(Object a) {
+Pointer<Utf8> _toStringProxy(Object arg0) {
   try {
-    return _toString!(a);
+    return _toString!(arg0);
   } catch (e) {
     _handle__to_string__set_error!(e);
     return Pointer.fromAddress(0);

--- a/flutter/lib/src/native/platform/parameters.dart
+++ b/flutter/lib/src/native/platform/parameters.dart
@@ -7,19 +7,18 @@ import 'parameters.g.dart' as bridge;
 /// Registers [RtpParameters] related functions in Rust.
 void registerFunctions(DynamicLibrary dl) {
   bridge.registerFunction(dl,
-      encodings: Pointer.fromFunction(_encodings),
-      setEncoding: Pointer.fromFunction(_setEncodings));
+      encodings: _encodings, setEncoding: _setEncodings);
 }
 
 /// Returns [SendEncodingParameters] from the provided [RtpParameters].
-Object _encodings(Object parameters) {
+List<SendEncodingParameters> Function() _encodings(Object parameters) {
   parameters as RtpParameters;
   return () => parameters.encodings;
 }
 
 /// Sets the provided [SendEncodingParameters] into the provided
 /// [RtpParameters].
-Object _setEncodings(Object parameters, Object encoding) {
+void Function() _setEncodings(Object parameters, Object encoding) {
   parameters as RtpParameters;
   encoding as SendEncodingParameters;
   return () => parameters.encodings.add(encoding);

--- a/flutter/lib/src/native/platform/parameters.g.dart
+++ b/flutter/lib/src/native/platform/parameters.g.dart
@@ -44,18 +44,18 @@ void registerFunction(
   );
 }
 
-Object _encodingsProxy(Object a) {
+Object _encodingsProxy(Object arg0) {
   try {
-    return _encodings!(a);
+    return _encodings!(arg0);
   } catch (e) {
     _parameters__encodings__set_error!(e);
     return 0;
   }
 }
 
-Object _setEncodingProxy(Object a, Object b) {
+Object _setEncodingProxy(Object arg0, Object arg1) {
   try {
-    return _setEncoding!(a, b);
+    return _setEncoding!(arg0, arg1);
   } catch (e) {
     _parameters__set_encoding__set_error!(e);
     return 0;

--- a/flutter/lib/src/native/platform/parameters.g.dart
+++ b/flutter/lib/src/native/platform/parameters.g.dart
@@ -4,14 +4,60 @@ import 'package:ffi/ffi.dart';
 
 import 'package:medea_jason/src/native/ffi/foreign_value.dart';
 
+typedef _ErrorSetterFnC = Void Function(Handle);
+typedef _ErrorSetterFnDart = void Function(Object);
+
+Object Function(Object)? _encodings;
+Object Function(Object, Object)? _setEncoding;
+
+_ErrorSetterFnDart? _parameters__encodings__set_error;
+_ErrorSetterFnDart? _parameters__set_encoding__set_error;
+
 void registerFunction(
   DynamicLibrary dl, {
-  required Pointer<NativeFunction<Handle Function(Handle)>> encodings,
-  required Pointer<NativeFunction<Handle Function(Handle, Handle)>> setEncoding,
+  required Object Function(Object) encodings,
+  required Object Function(Object, Object) setEncoding,
 }) {
+  _encodings = encodings;
+  _setEncoding = setEncoding;
+
+  _parameters__encodings__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'parameters__encodings__set_error');
+  _parameters__set_encoding__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'parameters__set_encoding__set_error');
+
+  Pointer<NativeFunction<Handle Function(Handle)>> encodings_native =
+      Pointer.fromFunction(
+    _encodingsProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Handle, Handle)>> setEncoding_native =
+      Pointer.fromFunction(
+    _setEncodingProxy,
+  );
+
   dl.lookupFunction<Void Function(Pointer, Pointer),
       void Function(Pointer, Pointer)>('register_parameters')(
-    encodings,
-    setEncoding,
+    encodings_native,
+    setEncoding_native,
   );
+}
+
+Object _encodingsProxy(Object a) {
+  try {
+    return _encodings!(a);
+  } catch (e) {
+    _parameters__encodings__set_error!(e);
+    return 0;
+  }
+}
+
+Object _setEncodingProxy(Object a, Object b) {
+  try {
+    return _setEncoding!(a, b);
+  } catch (e) {
+    _parameters__set_encoding__set_error!(e);
+    return 0;
+  }
 }

--- a/flutter/lib/src/native/platform/peer_connection.dart
+++ b/flutter/lib/src/native/platform/peer_connection.dart
@@ -13,33 +13,33 @@ import 'rtc_stats.dart';
 void registerFunctions(DynamicLibrary dl) {
   bridge.registerFunction(
     dl,
-    getStats: Pointer.fromFunction(_getStats),
-    setRemoteDescription: Pointer.fromFunction(_setRemoteDescription),
-    setLocalDescription: Pointer.fromFunction(_setLocalDescription),
-    addIceCandidate: Pointer.fromFunction(_addIceCandidate),
-    iceConnectionState: Pointer.fromFunction(_iceConnectionState, 0),
-    connectionState: Pointer.fromFunction(_connectionState),
-    restartIce: Pointer.fromFunction(_restartIce),
-    rollback: Pointer.fromFunction(_rollback),
-    onTrack: Pointer.fromFunction(_onTrack),
-    onIceCandidate: Pointer.fromFunction(_onIceCandidate),
-    onIceCandidateError: Pointer.fromFunction(_onIceCandidateError),
-    onIceConnectionStateChange:
-        Pointer.fromFunction(_onIceConnectionStateChange),
-    newPeer: Pointer.fromFunction(_newPeer),
-    addTransceiver: Pointer.fromFunction(_addTransceiver),
-    createOffer: Pointer.fromFunction(_createOffer),
-    createAnswer: Pointer.fromFunction(_createAnswer),
-    getTransceiverByMid: Pointer.fromFunction(_getTransceiverByMid),
-    onConnectionStateChange: Pointer.fromFunction(_onConnectionStateChange),
-    close: Pointer.fromFunction(_close),
+    getStats: _getStats,
+    setRemoteDescription: _setRemoteDescription,
+    setLocalDescription: _setLocalDescription,
+    addIceCandidate: _addIceCandidate,
+    iceConnectionState: _iceConnectionState,
+    connectionState: _connectionState,
+    restartIce: _restartIce,
+    rollback: _rollback,
+    onTrack: _onTrack,
+    onIceCandidate: _onIceCandidate,
+    onIceCandidateError: _onIceCandidateError,
+    onIceConnectionStateChange: _onIceConnectionStateChange,
+    newPeer: _newPeer,
+    addTransceiver: _addTransceiver,
+    createOffer: _createOffer,
+    createAnswer: _createAnswer,
+    getTransceiverByMid: _getTransceiverByMid,
+    onConnectionStateChange: _onConnectionStateChange,
+    close: _close,
   );
 }
 
 /// Adds an [RtpTransceiverInit] to the provided [PeerConnection].
 ///
 /// Returns [Future] which will be resolved into created [RtpTransceiver].
-Object _addTransceiver(Object peer, int kind, Object init) {
+Future<RtpTransceiver> Function() _addTransceiver(
+    Object peer, int kind, Object init) {
   peer as PeerConnection;
   init as RtpTransceiverInit;
   return () => peer.addTransceiver(MediaKind.values[kind], init);
@@ -47,7 +47,8 @@ Object _addTransceiver(Object peer, int kind, Object init) {
 
 /// Returns a newly created [PeerConnection] with the provided `iceServers`
 /// [List].
-Object _newPeer(Object iceServers, bool isForceRelayed) {
+Future<PeerConnection> Function() _newPeer(
+    Object iceServers, bool isForceRelayed) {
   var servers = iceServers as List<dynamic>;
   var iceType = isForceRelayed ? IceTransportType.relay : IceTransportType.all;
   return () => PeerConnection.create(
@@ -103,7 +104,7 @@ void _onConnectionStateChange(Object conn, Object f) {
 
 /// Returns JSON encoded [Array] of [RtcStats] from the provided
 /// [PeerConnection].
-Object _getStats(Object conn) {
+Future<String> Function() _getStats(Object conn) {
   conn as PeerConnection;
   return () async {
     var stats = await conn.getStats();
@@ -114,7 +115,8 @@ Object _getStats(Object conn) {
 
 /// Lookups an [RtpTransceiver] in the provided [PeerConnection] by the provided
 /// [mid].
-Object _getTransceiverByMid(Object peer, Pointer<Utf8> mid) {
+Future<RtpTransceiver?> Function() _getTransceiverByMid(
+    Object peer, Pointer<Utf8> mid) {
   peer as PeerConnection;
   return () => peer.getTransceivers().then((transceivers) {
         var mMid = mid.nativeStringToDartString();
@@ -131,7 +133,7 @@ Object _getTransceiverByMid(Object peer, Pointer<Utf8> mid) {
 }
 
 /// Sets a remote SDP offer in the provided [PeerConnection].
-Object _setRemoteDescription(
+Future<void> Function() _setRemoteDescription(
     Object conn, Pointer<Utf8> type, Pointer<Utf8> sdp) {
   conn as PeerConnection;
   SessionDescriptionType sdpType;
@@ -145,7 +147,7 @@ Object _setRemoteDescription(
 }
 
 /// Sets a local SDP offer in the provided [PeerConnection].
-Object _setLocalDescription(
+Future<void> Function() _setLocalDescription(
     Object conn, Pointer<Utf8> type, Pointer<Utf8> sdp) {
   conn as PeerConnection;
   SessionDescriptionType sdpType;
@@ -159,13 +161,13 @@ Object _setLocalDescription(
 }
 
 /// Creates a new SDP offer for the provided [PeerConnection].
-Object _createOffer(Object conn) {
+Future<String> Function() _createOffer(Object conn) {
   conn as PeerConnection;
   return () => conn.createOffer().then((val) => val.description);
 }
 
 /// Creates a new SDP answer for the provided [PeerConnection].
-Object _createAnswer(Object conn) {
+Future<String> Function() _createAnswer(Object conn) {
   conn as PeerConnection;
   return () => conn.createAnswer().then((val) => val.description);
 }
@@ -178,7 +180,7 @@ void _restartIce(Object conn) {
 }
 
 /// Adds the specified [IceCandidate] to the provided [PeerConnection].
-Object _addIceCandidate(Object conn, Object candidate) {
+Future<void> Function() _addIceCandidate(Object conn, Object candidate) {
   conn as PeerConnection;
   candidate as IceCandidate;
   return () => conn.addIceCandidate(candidate);
@@ -199,14 +201,14 @@ int _iceConnectionState(Object conn) {
 }
 
 /// Rollbacks the local SDP offer of the provided [PeerConnection].
-Object _rollback(Object conn) {
+Future<void> Function() _rollback(Object conn) {
   conn as PeerConnection;
   return () => conn.setLocalDescription(
       SessionDescription(SessionDescriptionType.rollback, ''));
 }
 
 /// Returns all the [RtpTransceiver]s of the provided [PeerConnection].
-Object getTransceivers(Object conn) {
+Future<List<RtpTransceiver>> Function() getTransceivers(Object conn) {
   conn as PeerConnection;
   return () => conn.getTransceivers();
 }

--- a/flutter/lib/src/native/platform/peer_connection.g.dart
+++ b/flutter/lib/src/native/platform/peer_connection.g.dart
@@ -287,171 +287,173 @@ void registerFunction(
   );
 }
 
-int _iceConnectionStateProxy(Object a) {
+int _iceConnectionStateProxy(Object arg0) {
   try {
-    return _iceConnectionState!(a);
+    return _iceConnectionState!(arg0);
   } catch (e) {
     _peer_connection__ice_connection_state__set_error!(e);
     return 0;
   }
 }
 
-void _onConnectionStateChangeProxy(Object a, Object b) {
+void _onConnectionStateChangeProxy(Object arg0, Object arg1) {
   try {
-    return _onConnectionStateChange!(a, b);
+    return _onConnectionStateChange!(arg0, arg1);
   } catch (e) {
     _peer_connection__on_connection_state_change__set_error!(e);
     return;
   }
 }
 
-Pointer _connectionStateProxy(Object a) {
+Pointer _connectionStateProxy(Object arg0) {
   try {
-    return _connectionState!(a);
+    return _connectionState!(arg0);
   } catch (e) {
     _peer_connection__connection_state__set_error!(e);
     return Pointer.fromAddress(0);
   }
 }
 
-void _restartIceProxy(Object a) {
+void _restartIceProxy(Object arg0) {
   try {
-    return _restartIce!(a);
+    return _restartIce!(arg0);
   } catch (e) {
     _peer_connection__restart_ice__set_error!(e);
     return;
   }
 }
 
-Object _rollbackProxy(Object a) {
+Object _rollbackProxy(Object arg0) {
   try {
-    return _rollback!(a);
+    return _rollback!(arg0);
   } catch (e) {
     _peer_connection__rollback__set_error!(e);
     return 0;
   }
 }
 
-Object _getStatsProxy(Object a) {
+Object _getStatsProxy(Object arg0) {
   try {
-    return _getStats!(a);
+    return _getStats!(arg0);
   } catch (e) {
     _peer_connection__get_stats__set_error!(e);
     return 0;
   }
 }
 
-void _onTrackProxy(Object a, Object b) {
+void _onTrackProxy(Object arg0, Object arg1) {
   try {
-    return _onTrack!(a, b);
+    return _onTrack!(arg0, arg1);
   } catch (e) {
     _peer_connection__on_track__set_error!(e);
     return;
   }
 }
 
-void _onIceCandidateProxy(Object a, Object b) {
+void _onIceCandidateProxy(Object arg0, Object arg1) {
   try {
-    return _onIceCandidate!(a, b);
+    return _onIceCandidate!(arg0, arg1);
   } catch (e) {
     _peer_connection__on_ice_candidate__set_error!(e);
     return;
   }
 }
 
-void _onIceCandidateErrorProxy(Object a, Object b) {
+void _onIceCandidateErrorProxy(Object arg0, Object arg1) {
   try {
-    return _onIceCandidateError!(a, b);
+    return _onIceCandidateError!(arg0, arg1);
   } catch (e) {
     _peer_connection__on_ice_candidate_error__set_error!(e);
     return;
   }
 }
 
-Object _getTransceiverByMidProxy(Object a, Pointer<Utf8> b) {
+Object _getTransceiverByMidProxy(Object arg0, Pointer<Utf8> arg1) {
   try {
-    return _getTransceiverByMid!(a, b);
+    return _getTransceiverByMid!(arg0, arg1);
   } catch (e) {
     _peer_connection__get_transceiver_by_mid__set_error!(e);
     return 0;
   }
 }
 
-Object _addIceCandidateProxy(Object a, Object b) {
+Object _addIceCandidateProxy(Object arg0, Object arg1) {
   try {
-    return _addIceCandidate!(a, b);
+    return _addIceCandidate!(arg0, arg1);
   } catch (e) {
     _peer_connection__add_ice_candidate__set_error!(e);
     return 0;
   }
 }
 
-void _onIceConnectionStateChangeProxy(Object a, Object b) {
+void _onIceConnectionStateChangeProxy(Object arg0, Object arg1) {
   try {
-    return _onIceConnectionStateChange!(a, b);
+    return _onIceConnectionStateChange!(arg0, arg1);
   } catch (e) {
     _peer_connection__on_ice_connection_state_change__set_error!(e);
     return;
   }
 }
 
-Object _newPeerProxy(Object a, bool b) {
+Object _newPeerProxy(Object arg0, bool arg1) {
   try {
-    return _newPeer!(a, b);
+    return _newPeer!(arg0, arg1);
   } catch (e) {
     _peer_connection__new_peer__set_error!(e);
     return 0;
   }
 }
 
-Object _addTransceiverProxy(Object a, int b, Object c) {
+Object _addTransceiverProxy(Object arg0, int arg1, Object arg2) {
   try {
-    return _addTransceiver!(a, b, c);
+    return _addTransceiver!(arg0, arg1, arg2);
   } catch (e) {
     _peer_connection__add_transceiver__set_error!(e);
     return 0;
   }
 }
 
-Object _createOfferProxy(Object a) {
+Object _createOfferProxy(Object arg0) {
   try {
-    return _createOffer!(a);
+    return _createOffer!(arg0);
   } catch (e) {
     _peer_connection__create_offer__set_error!(e);
     return 0;
   }
 }
 
-Object _createAnswerProxy(Object a) {
+Object _createAnswerProxy(Object arg0) {
   try {
-    return _createAnswer!(a);
+    return _createAnswer!(arg0);
   } catch (e) {
     _peer_connection__create_answer__set_error!(e);
     return 0;
   }
 }
 
-Object _setLocalDescriptionProxy(Object a, Pointer<Utf8> b, Pointer<Utf8> c) {
+Object _setLocalDescriptionProxy(
+    Object arg0, Pointer<Utf8> arg1, Pointer<Utf8> arg2) {
   try {
-    return _setLocalDescription!(a, b, c);
+    return _setLocalDescription!(arg0, arg1, arg2);
   } catch (e) {
     _peer_connection__set_local_description__set_error!(e);
     return 0;
   }
 }
 
-Object _setRemoteDescriptionProxy(Object a, Pointer<Utf8> b, Pointer<Utf8> c) {
+Object _setRemoteDescriptionProxy(
+    Object arg0, Pointer<Utf8> arg1, Pointer<Utf8> arg2) {
   try {
-    return _setRemoteDescription!(a, b, c);
+    return _setRemoteDescription!(arg0, arg1, arg2);
   } catch (e) {
     _peer_connection__set_remote_description__set_error!(e);
     return 0;
   }
 }
 
-void _closeProxy(Object a) {
+void _closeProxy(Object arg0) {
   try {
-    return _close!(a);
+    return _close!(arg0);
   } catch (e) {
     _peer_connection__close__set_error!(e);
     return;

--- a/flutter/lib/src/native/platform/peer_connection.g.dart
+++ b/flutter/lib/src/native/platform/peer_connection.g.dart
@@ -4,39 +4,226 @@ import 'package:ffi/ffi.dart';
 
 import 'package:medea_jason/src/native/ffi/foreign_value.dart';
 
+typedef _ErrorSetterFnC = Void Function(Handle);
+typedef _ErrorSetterFnDart = void Function(Object);
+
+int Function(Object)? _iceConnectionState;
+void Function(Object, Object)? _onConnectionStateChange;
+Pointer Function(Object)? _connectionState;
+void Function(Object)? _restartIce;
+Object Function(Object)? _rollback;
+Object Function(Object)? _getStats;
+void Function(Object, Object)? _onTrack;
+void Function(Object, Object)? _onIceCandidate;
+void Function(Object, Object)? _onIceCandidateError;
+Object Function(Object, Pointer<Utf8>)? _getTransceiverByMid;
+Object Function(Object, Object)? _addIceCandidate;
+void Function(Object, Object)? _onIceConnectionStateChange;
+Object Function(Object, bool)? _newPeer;
+Object Function(Object, int, Object)? _addTransceiver;
+Object Function(Object)? _createOffer;
+Object Function(Object)? _createAnswer;
+Object Function(Object, Pointer<Utf8>, Pointer<Utf8>)? _setLocalDescription;
+Object Function(Object, Pointer<Utf8>, Pointer<Utf8>)? _setRemoteDescription;
+void Function(Object)? _close;
+
+_ErrorSetterFnDart? _peer_connection__ice_connection_state__set_error;
+_ErrorSetterFnDart? _peer_connection__on_connection_state_change__set_error;
+_ErrorSetterFnDart? _peer_connection__connection_state__set_error;
+_ErrorSetterFnDart? _peer_connection__restart_ice__set_error;
+_ErrorSetterFnDart? _peer_connection__rollback__set_error;
+_ErrorSetterFnDart? _peer_connection__get_stats__set_error;
+_ErrorSetterFnDart? _peer_connection__on_track__set_error;
+_ErrorSetterFnDart? _peer_connection__on_ice_candidate__set_error;
+_ErrorSetterFnDart? _peer_connection__on_ice_candidate_error__set_error;
+_ErrorSetterFnDart? _peer_connection__get_transceiver_by_mid__set_error;
+_ErrorSetterFnDart? _peer_connection__add_ice_candidate__set_error;
+_ErrorSetterFnDart? _peer_connection__on_ice_connection_state_change__set_error;
+_ErrorSetterFnDart? _peer_connection__new_peer__set_error;
+_ErrorSetterFnDart? _peer_connection__add_transceiver__set_error;
+_ErrorSetterFnDart? _peer_connection__create_offer__set_error;
+_ErrorSetterFnDart? _peer_connection__create_answer__set_error;
+_ErrorSetterFnDart? _peer_connection__set_local_description__set_error;
+_ErrorSetterFnDart? _peer_connection__set_remote_description__set_error;
+_ErrorSetterFnDart? _peer_connection__close__set_error;
+
 void registerFunction(
   DynamicLibrary dl, {
-  required Pointer<NativeFunction<Int32 Function(Handle)>> iceConnectionState,
-  required Pointer<NativeFunction<Void Function(Handle, Handle)>>
-      onConnectionStateChange,
-  required Pointer<NativeFunction<Pointer Function(Handle)>> connectionState,
-  required Pointer<NativeFunction<Void Function(Handle)>> restartIce,
-  required Pointer<NativeFunction<Handle Function(Handle)>> rollback,
-  required Pointer<NativeFunction<Handle Function(Handle)>> getStats,
-  required Pointer<NativeFunction<Void Function(Handle, Handle)>> onTrack,
-  required Pointer<NativeFunction<Void Function(Handle, Handle)>>
-      onIceCandidate,
-  required Pointer<NativeFunction<Void Function(Handle, Handle)>>
-      onIceCandidateError,
-  required Pointer<NativeFunction<Handle Function(Handle, Pointer<Utf8>)>>
-      getTransceiverByMid,
-  required Pointer<NativeFunction<Handle Function(Handle, Handle)>>
-      addIceCandidate,
-  required Pointer<NativeFunction<Void Function(Handle, Handle)>>
-      onIceConnectionStateChange,
-  required Pointer<NativeFunction<Handle Function(Handle, Bool)>> newPeer,
-  required Pointer<NativeFunction<Handle Function(Handle, Int64, Handle)>>
-      addTransceiver,
-  required Pointer<NativeFunction<Handle Function(Handle)>> createOffer,
-  required Pointer<NativeFunction<Handle Function(Handle)>> createAnswer,
-  required Pointer<
-          NativeFunction<Handle Function(Handle, Pointer<Utf8>, Pointer<Utf8>)>>
+  required int Function(Object) iceConnectionState,
+  required void Function(Object, Object) onConnectionStateChange,
+  required Pointer Function(Object) connectionState,
+  required void Function(Object) restartIce,
+  required Object Function(Object) rollback,
+  required Object Function(Object) getStats,
+  required void Function(Object, Object) onTrack,
+  required void Function(Object, Object) onIceCandidate,
+  required void Function(Object, Object) onIceCandidateError,
+  required Object Function(Object, Pointer<Utf8>) getTransceiverByMid,
+  required Object Function(Object, Object) addIceCandidate,
+  required void Function(Object, Object) onIceConnectionStateChange,
+  required Object Function(Object, bool) newPeer,
+  required Object Function(Object, int, Object) addTransceiver,
+  required Object Function(Object) createOffer,
+  required Object Function(Object) createAnswer,
+  required Object Function(Object, Pointer<Utf8>, Pointer<Utf8>)
       setLocalDescription,
-  required Pointer<
-          NativeFunction<Handle Function(Handle, Pointer<Utf8>, Pointer<Utf8>)>>
+  required Object Function(Object, Pointer<Utf8>, Pointer<Utf8>)
       setRemoteDescription,
-  required Pointer<NativeFunction<Void Function(Handle)>> close,
+  required void Function(Object) close,
 }) {
+  _iceConnectionState = iceConnectionState;
+  _onConnectionStateChange = onConnectionStateChange;
+  _connectionState = connectionState;
+  _restartIce = restartIce;
+  _rollback = rollback;
+  _getStats = getStats;
+  _onTrack = onTrack;
+  _onIceCandidate = onIceCandidate;
+  _onIceCandidateError = onIceCandidateError;
+  _getTransceiverByMid = getTransceiverByMid;
+  _addIceCandidate = addIceCandidate;
+  _onIceConnectionStateChange = onIceConnectionStateChange;
+  _newPeer = newPeer;
+  _addTransceiver = addTransceiver;
+  _createOffer = createOffer;
+  _createAnswer = createAnswer;
+  _setLocalDescription = setLocalDescription;
+  _setRemoteDescription = setRemoteDescription;
+  _close = close;
+
+  _peer_connection__ice_connection_state__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'peer_connection__ice_connection_state__set_error');
+  _peer_connection__on_connection_state_change__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'peer_connection__on_connection_state_change__set_error');
+  _peer_connection__connection_state__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'peer_connection__connection_state__set_error');
+  _peer_connection__restart_ice__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'peer_connection__restart_ice__set_error');
+  _peer_connection__rollback__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'peer_connection__rollback__set_error');
+  _peer_connection__get_stats__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'peer_connection__get_stats__set_error');
+  _peer_connection__on_track__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'peer_connection__on_track__set_error');
+  _peer_connection__on_ice_candidate__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'peer_connection__on_ice_candidate__set_error');
+  _peer_connection__on_ice_candidate_error__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'peer_connection__on_ice_candidate_error__set_error');
+  _peer_connection__get_transceiver_by_mid__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'peer_connection__get_transceiver_by_mid__set_error');
+  _peer_connection__add_ice_candidate__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'peer_connection__add_ice_candidate__set_error');
+  _peer_connection__on_ice_connection_state_change__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'peer_connection__on_ice_connection_state_change__set_error');
+  _peer_connection__new_peer__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'peer_connection__new_peer__set_error');
+  _peer_connection__add_transceiver__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'peer_connection__add_transceiver__set_error');
+  _peer_connection__create_offer__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'peer_connection__create_offer__set_error');
+  _peer_connection__create_answer__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'peer_connection__create_answer__set_error');
+  _peer_connection__set_local_description__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'peer_connection__set_local_description__set_error');
+  _peer_connection__set_remote_description__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'peer_connection__set_remote_description__set_error');
+  _peer_connection__close__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'peer_connection__close__set_error');
+
+  Pointer<NativeFunction<Int32 Function(Handle)>> iceConnectionState_native =
+      Pointer.fromFunction(_iceConnectionStateProxy, 0);
+  Pointer<NativeFunction<Void Function(Handle, Handle)>>
+      onConnectionStateChange_native = Pointer.fromFunction(
+    _onConnectionStateChangeProxy,
+  );
+  Pointer<NativeFunction<Pointer Function(Handle)>> connectionState_native =
+      Pointer.fromFunction(
+    _connectionStateProxy,
+  );
+  Pointer<NativeFunction<Void Function(Handle)>> restartIce_native =
+      Pointer.fromFunction(
+    _restartIceProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Handle)>> rollback_native =
+      Pointer.fromFunction(
+    _rollbackProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Handle)>> getStats_native =
+      Pointer.fromFunction(
+    _getStatsProxy,
+  );
+  Pointer<NativeFunction<Void Function(Handle, Handle)>> onTrack_native =
+      Pointer.fromFunction(
+    _onTrackProxy,
+  );
+  Pointer<NativeFunction<Void Function(Handle, Handle)>> onIceCandidate_native =
+      Pointer.fromFunction(
+    _onIceCandidateProxy,
+  );
+  Pointer<NativeFunction<Void Function(Handle, Handle)>>
+      onIceCandidateError_native = Pointer.fromFunction(
+    _onIceCandidateErrorProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Handle, Pointer<Utf8>)>>
+      getTransceiverByMid_native = Pointer.fromFunction(
+    _getTransceiverByMidProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Handle, Handle)>>
+      addIceCandidate_native = Pointer.fromFunction(
+    _addIceCandidateProxy,
+  );
+  Pointer<NativeFunction<Void Function(Handle, Handle)>>
+      onIceConnectionStateChange_native = Pointer.fromFunction(
+    _onIceConnectionStateChangeProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Handle, Bool)>> newPeer_native =
+      Pointer.fromFunction(
+    _newPeerProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Handle, Int64, Handle)>>
+      addTransceiver_native = Pointer.fromFunction(
+    _addTransceiverProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Handle)>> createOffer_native =
+      Pointer.fromFunction(
+    _createOfferProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Handle)>> createAnswer_native =
+      Pointer.fromFunction(
+    _createAnswerProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Handle, Pointer<Utf8>, Pointer<Utf8>)>>
+      setLocalDescription_native = Pointer.fromFunction(
+    _setLocalDescriptionProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Handle, Pointer<Utf8>, Pointer<Utf8>)>>
+      setRemoteDescription_native = Pointer.fromFunction(
+    _setRemoteDescriptionProxy,
+  );
+  Pointer<NativeFunction<Void Function(Handle)>> close_native =
+      Pointer.fromFunction(
+    _closeProxy,
+  );
+
   dl.lookupFunction<
       Void Function(
           Pointer,
@@ -78,24 +265,195 @@ void registerFunction(
           Pointer,
           Pointer,
           Pointer)>('register_peer_connection')(
-    iceConnectionState,
-    onConnectionStateChange,
-    connectionState,
-    restartIce,
-    rollback,
-    getStats,
-    onTrack,
-    onIceCandidate,
-    onIceCandidateError,
-    getTransceiverByMid,
-    addIceCandidate,
-    onIceConnectionStateChange,
-    newPeer,
-    addTransceiver,
-    createOffer,
-    createAnswer,
-    setLocalDescription,
-    setRemoteDescription,
-    close,
+    iceConnectionState_native,
+    onConnectionStateChange_native,
+    connectionState_native,
+    restartIce_native,
+    rollback_native,
+    getStats_native,
+    onTrack_native,
+    onIceCandidate_native,
+    onIceCandidateError_native,
+    getTransceiverByMid_native,
+    addIceCandidate_native,
+    onIceConnectionStateChange_native,
+    newPeer_native,
+    addTransceiver_native,
+    createOffer_native,
+    createAnswer_native,
+    setLocalDescription_native,
+    setRemoteDescription_native,
+    close_native,
   );
+}
+
+int _iceConnectionStateProxy(Object a) {
+  try {
+    return _iceConnectionState!(a);
+  } catch (e) {
+    _peer_connection__ice_connection_state__set_error!(e);
+    return 0;
+  }
+}
+
+void _onConnectionStateChangeProxy(Object a, Object b) {
+  try {
+    return _onConnectionStateChange!(a, b);
+  } catch (e) {
+    _peer_connection__on_connection_state_change__set_error!(e);
+    return;
+  }
+}
+
+Pointer _connectionStateProxy(Object a) {
+  try {
+    return _connectionState!(a);
+  } catch (e) {
+    _peer_connection__connection_state__set_error!(e);
+    return Pointer.fromAddress(0);
+  }
+}
+
+void _restartIceProxy(Object a) {
+  try {
+    return _restartIce!(a);
+  } catch (e) {
+    _peer_connection__restart_ice__set_error!(e);
+    return;
+  }
+}
+
+Object _rollbackProxy(Object a) {
+  try {
+    return _rollback!(a);
+  } catch (e) {
+    _peer_connection__rollback__set_error!(e);
+    return 0;
+  }
+}
+
+Object _getStatsProxy(Object a) {
+  try {
+    return _getStats!(a);
+  } catch (e) {
+    _peer_connection__get_stats__set_error!(e);
+    return 0;
+  }
+}
+
+void _onTrackProxy(Object a, Object b) {
+  try {
+    return _onTrack!(a, b);
+  } catch (e) {
+    _peer_connection__on_track__set_error!(e);
+    return;
+  }
+}
+
+void _onIceCandidateProxy(Object a, Object b) {
+  try {
+    return _onIceCandidate!(a, b);
+  } catch (e) {
+    _peer_connection__on_ice_candidate__set_error!(e);
+    return;
+  }
+}
+
+void _onIceCandidateErrorProxy(Object a, Object b) {
+  try {
+    return _onIceCandidateError!(a, b);
+  } catch (e) {
+    _peer_connection__on_ice_candidate_error__set_error!(e);
+    return;
+  }
+}
+
+Object _getTransceiverByMidProxy(Object a, Pointer<Utf8> b) {
+  try {
+    return _getTransceiverByMid!(a, b);
+  } catch (e) {
+    _peer_connection__get_transceiver_by_mid__set_error!(e);
+    return 0;
+  }
+}
+
+Object _addIceCandidateProxy(Object a, Object b) {
+  try {
+    return _addIceCandidate!(a, b);
+  } catch (e) {
+    _peer_connection__add_ice_candidate__set_error!(e);
+    return 0;
+  }
+}
+
+void _onIceConnectionStateChangeProxy(Object a, Object b) {
+  try {
+    return _onIceConnectionStateChange!(a, b);
+  } catch (e) {
+    _peer_connection__on_ice_connection_state_change__set_error!(e);
+    return;
+  }
+}
+
+Object _newPeerProxy(Object a, bool b) {
+  try {
+    return _newPeer!(a, b);
+  } catch (e) {
+    _peer_connection__new_peer__set_error!(e);
+    return 0;
+  }
+}
+
+Object _addTransceiverProxy(Object a, int b, Object c) {
+  try {
+    return _addTransceiver!(a, b, c);
+  } catch (e) {
+    _peer_connection__add_transceiver__set_error!(e);
+    return 0;
+  }
+}
+
+Object _createOfferProxy(Object a) {
+  try {
+    return _createOffer!(a);
+  } catch (e) {
+    _peer_connection__create_offer__set_error!(e);
+    return 0;
+  }
+}
+
+Object _createAnswerProxy(Object a) {
+  try {
+    return _createAnswer!(a);
+  } catch (e) {
+    _peer_connection__create_answer__set_error!(e);
+    return 0;
+  }
+}
+
+Object _setLocalDescriptionProxy(Object a, Pointer<Utf8> b, Pointer<Utf8> c) {
+  try {
+    return _setLocalDescription!(a, b, c);
+  } catch (e) {
+    _peer_connection__set_local_description__set_error!(e);
+    return 0;
+  }
+}
+
+Object _setRemoteDescriptionProxy(Object a, Pointer<Utf8> b, Pointer<Utf8> c) {
+  try {
+    return _setRemoteDescription!(a, b, c);
+  } catch (e) {
+    _peer_connection__set_remote_description__set_error!(e);
+    return 0;
+  }
+}
+
+void _closeProxy(Object a) {
+  try {
+    return _close!(a);
+  } catch (e) {
+    _peer_connection__close__set_error!(e);
+    return;
+  }
 }

--- a/flutter/lib/src/native/platform/send_encoding_parameters.dart
+++ b/flutter/lib/src/native/platform/send_encoding_parameters.dart
@@ -10,17 +10,18 @@ import 'send_encoding_parameters.g.dart' as bridge;
 void registerFunctions(DynamicLibrary dl) {
   bridge.registerFunction(
     dl,
-    newSendEncodingParameters: Pointer.fromFunction(_newSendEncodingParameters),
-    getRid: Pointer.fromFunction(_getRid),
-    setActive: Pointer.fromFunction(_setActive),
-    setMaxBitrate: Pointer.fromFunction(_setMaxBitrate),
-    setScaleResolutionDownBy: Pointer.fromFunction(_setScaleResolutionDownBy),
-    setScalabilityMode: Pointer.fromFunction(_setScalabilityMode),
+    newSendEncodingParameters: _newSendEncodingParameters,
+    getRid: _getRid,
+    setActive: _setActive,
+    setMaxBitrate: _setMaxBitrate,
+    setScaleResolutionDownBy: _setScaleResolutionDownBy,
+    setScalabilityMode: _setScalabilityMode,
   );
 }
 
 /// Creates new [SendEncodingParameters].
-Object _newSendEncodingParameters(Pointer<Utf8> rid, bool active) {
+SendEncodingParameters _newSendEncodingParameters(
+    Pointer<Utf8> rid, bool active) {
   return SendEncodingParameters.create(rid.nativeStringToDartString(), active);
 }
 

--- a/flutter/lib/src/native/platform/send_encoding_parameters.g.dart
+++ b/flutter/lib/src/native/platform/send_encoding_parameters.g.dart
@@ -4,27 +4,148 @@ import 'package:ffi/ffi.dart';
 
 import 'package:medea_jason/src/native/ffi/foreign_value.dart';
 
+typedef _ErrorSetterFnC = Void Function(Handle);
+typedef _ErrorSetterFnDart = void Function(Object);
+
+Object Function(Pointer<Utf8>, bool)? _newSendEncodingParameters;
+Pointer<Utf8> Function(Object)? _getRid;
+void Function(Object, bool)? _setActive;
+void Function(Object, int)? _setMaxBitrate;
+void Function(Object, int)? _setScaleResolutionDownBy;
+void Function(Object, Pointer<Utf8>)? _setScalabilityMode;
+
+_ErrorSetterFnDart?
+    _send_encoding_parameters__new_send_encoding_parameters__set_error;
+_ErrorSetterFnDart? _send_encoding_parameters__get_rid__set_error;
+_ErrorSetterFnDart? _send_encoding_parameters__set_active__set_error;
+_ErrorSetterFnDart? _send_encoding_parameters__set_max_bitrate__set_error;
+_ErrorSetterFnDart?
+    _send_encoding_parameters__set_scale_resolution_down_by__set_error;
+_ErrorSetterFnDart? _send_encoding_parameters__set_scalability_mode__set_error;
+
 void registerFunction(
   DynamicLibrary dl, {
-  required Pointer<NativeFunction<Handle Function(Pointer<Utf8>, Bool)>>
-      newSendEncodingParameters,
-  required Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> getRid,
-  required Pointer<NativeFunction<Void Function(Handle, Bool)>> setActive,
-  required Pointer<NativeFunction<Void Function(Handle, Int64)>> setMaxBitrate,
-  required Pointer<NativeFunction<Void Function(Handle, Int64)>>
-      setScaleResolutionDownBy,
-  required Pointer<NativeFunction<Void Function(Handle, Pointer<Utf8>)>>
-      setScalabilityMode,
+  required Object Function(Pointer<Utf8>, bool) newSendEncodingParameters,
+  required Pointer<Utf8> Function(Object) getRid,
+  required void Function(Object, bool) setActive,
+  required void Function(Object, int) setMaxBitrate,
+  required void Function(Object, int) setScaleResolutionDownBy,
+  required void Function(Object, Pointer<Utf8>) setScalabilityMode,
 }) {
+  _newSendEncodingParameters = newSendEncodingParameters;
+  _getRid = getRid;
+  _setActive = setActive;
+  _setMaxBitrate = setMaxBitrate;
+  _setScaleResolutionDownBy = setScaleResolutionDownBy;
+  _setScalabilityMode = setScalabilityMode;
+
+  _send_encoding_parameters__new_send_encoding_parameters__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'send_encoding_parameters__new_send_encoding_parameters__set_error');
+  _send_encoding_parameters__get_rid__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'send_encoding_parameters__get_rid__set_error');
+  _send_encoding_parameters__set_active__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'send_encoding_parameters__set_active__set_error');
+  _send_encoding_parameters__set_max_bitrate__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'send_encoding_parameters__set_max_bitrate__set_error');
+  _send_encoding_parameters__set_scale_resolution_down_by__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'send_encoding_parameters__set_scale_resolution_down_by__set_error');
+  _send_encoding_parameters__set_scalability_mode__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'send_encoding_parameters__set_scalability_mode__set_error');
+
+  Pointer<NativeFunction<Handle Function(Pointer<Utf8>, Bool)>>
+      newSendEncodingParameters_native = Pointer.fromFunction(
+    _newSendEncodingParametersProxy,
+  );
+  Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> getRid_native =
+      Pointer.fromFunction(
+    _getRidProxy,
+  );
+  Pointer<NativeFunction<Void Function(Handle, Bool)>> setActive_native =
+      Pointer.fromFunction(
+    _setActiveProxy,
+  );
+  Pointer<NativeFunction<Void Function(Handle, Int64)>> setMaxBitrate_native =
+      Pointer.fromFunction(
+    _setMaxBitrateProxy,
+  );
+  Pointer<NativeFunction<Void Function(Handle, Int64)>>
+      setScaleResolutionDownBy_native = Pointer.fromFunction(
+    _setScaleResolutionDownByProxy,
+  );
+  Pointer<NativeFunction<Void Function(Handle, Pointer<Utf8>)>>
+      setScalabilityMode_native = Pointer.fromFunction(
+    _setScalabilityModeProxy,
+  );
+
   dl.lookupFunction<
       Void Function(Pointer, Pointer, Pointer, Pointer, Pointer, Pointer),
       void Function(Pointer, Pointer, Pointer, Pointer, Pointer,
           Pointer)>('register_send_encoding_parameters')(
-    newSendEncodingParameters,
-    getRid,
-    setActive,
-    setMaxBitrate,
-    setScaleResolutionDownBy,
-    setScalabilityMode,
+    newSendEncodingParameters_native,
+    getRid_native,
+    setActive_native,
+    setMaxBitrate_native,
+    setScaleResolutionDownBy_native,
+    setScalabilityMode_native,
   );
+}
+
+Object _newSendEncodingParametersProxy(Pointer<Utf8> a, bool b) {
+  try {
+    return _newSendEncodingParameters!(a, b);
+  } catch (e) {
+    _send_encoding_parameters__new_send_encoding_parameters__set_error!(e);
+    return 0;
+  }
+}
+
+Pointer<Utf8> _getRidProxy(Object a) {
+  try {
+    return _getRid!(a);
+  } catch (e) {
+    _send_encoding_parameters__get_rid__set_error!(e);
+    return Pointer.fromAddress(0);
+  }
+}
+
+void _setActiveProxy(Object a, bool b) {
+  try {
+    return _setActive!(a, b);
+  } catch (e) {
+    _send_encoding_parameters__set_active__set_error!(e);
+    return;
+  }
+}
+
+void _setMaxBitrateProxy(Object a, int b) {
+  try {
+    return _setMaxBitrate!(a, b);
+  } catch (e) {
+    _send_encoding_parameters__set_max_bitrate__set_error!(e);
+    return;
+  }
+}
+
+void _setScaleResolutionDownByProxy(Object a, int b) {
+  try {
+    return _setScaleResolutionDownBy!(a, b);
+  } catch (e) {
+    _send_encoding_parameters__set_scale_resolution_down_by__set_error!(e);
+    return;
+  }
+}
+
+void _setScalabilityModeProxy(Object a, Pointer<Utf8> b) {
+  try {
+    return _setScalabilityMode!(a, b);
+  } catch (e) {
+    _send_encoding_parameters__set_scalability_mode__set_error!(e);
+    return;
+  }
 }

--- a/flutter/lib/src/native/platform/send_encoding_parameters.g.dart
+++ b/flutter/lib/src/native/platform/send_encoding_parameters.g.dart
@@ -96,54 +96,54 @@ void registerFunction(
   );
 }
 
-Object _newSendEncodingParametersProxy(Pointer<Utf8> a, bool b) {
+Object _newSendEncodingParametersProxy(Pointer<Utf8> arg0, bool arg1) {
   try {
-    return _newSendEncodingParameters!(a, b);
+    return _newSendEncodingParameters!(arg0, arg1);
   } catch (e) {
     _send_encoding_parameters__new_send_encoding_parameters__set_error!(e);
     return 0;
   }
 }
 
-Pointer<Utf8> _getRidProxy(Object a) {
+Pointer<Utf8> _getRidProxy(Object arg0) {
   try {
-    return _getRid!(a);
+    return _getRid!(arg0);
   } catch (e) {
     _send_encoding_parameters__get_rid__set_error!(e);
     return Pointer.fromAddress(0);
   }
 }
 
-void _setActiveProxy(Object a, bool b) {
+void _setActiveProxy(Object arg0, bool arg1) {
   try {
-    return _setActive!(a, b);
+    return _setActive!(arg0, arg1);
   } catch (e) {
     _send_encoding_parameters__set_active__set_error!(e);
     return;
   }
 }
 
-void _setMaxBitrateProxy(Object a, int b) {
+void _setMaxBitrateProxy(Object arg0, int arg1) {
   try {
-    return _setMaxBitrate!(a, b);
+    return _setMaxBitrate!(arg0, arg1);
   } catch (e) {
     _send_encoding_parameters__set_max_bitrate__set_error!(e);
     return;
   }
 }
 
-void _setScaleResolutionDownByProxy(Object a, int b) {
+void _setScaleResolutionDownByProxy(Object arg0, int arg1) {
   try {
-    return _setScaleResolutionDownBy!(a, b);
+    return _setScaleResolutionDownBy!(arg0, arg1);
   } catch (e) {
     _send_encoding_parameters__set_scale_resolution_down_by__set_error!(e);
     return;
   }
 }
 
-void _setScalabilityModeProxy(Object a, Pointer<Utf8> b) {
+void _setScalabilityModeProxy(Object arg0, Pointer<Utf8> arg1) {
   try {
-    return _setScalabilityMode!(a, b);
+    return _setScalabilityMode!(arg0, arg1);
   } catch (e) {
     _send_encoding_parameters__set_scalability_mode__set_error!(e);
     return;

--- a/flutter/lib/src/native/platform/transceiver.dart
+++ b/flutter/lib/src/native/platform/transceiver.dart
@@ -115,6 +115,6 @@ Future<void> Function() _setSendParameters(
 /// [RtpCodecCapability] for the provided [RtpTransceiver].
 void _setCodecPreferences(Object transceiver, Object codecCapability) {
   transceiver as RtpTransceiver;
-  codecCapability as List<RtpCodecCapability>;
-  transceiver.setCodecPreferences(codecCapability);
+  codecCapability as List;
+  transceiver.setCodecPreferences(codecCapability.cast<RtpCodecCapability>());
 }

--- a/flutter/lib/src/native/platform/transceiver.dart
+++ b/flutter/lib/src/native/platform/transceiver.dart
@@ -9,25 +9,24 @@ import 'transceiver.g.dart' as bridge;
 void registerFunctions(DynamicLibrary dl) {
   bridge.registerFunction(
     dl,
-    getDirection: Pointer.fromFunction(_getDirection),
-    replaceTrack: Pointer.fromFunction(_replaceSendTrack),
-    getSendTrack: Pointer.fromFunction(_getSendTrack),
-    dropSender: Pointer.fromFunction(_dropSender),
-    isStopped: Pointer.fromFunction(_isStopped, true),
-    mid: Pointer.fromFunction(_mid),
-    setRecv: Pointer.fromFunction(_setRecv),
-    setSend: Pointer.fromFunction(_setSend),
-    dispose: Pointer.fromFunction(_dispose),
-    createTransceiverInit: Pointer.fromFunction(_createTransceiverInit),
-    addSendingEncodings: Pointer.fromFunction(_addSendingEncodings),
-    getSendParameters: Pointer.fromFunction(_getSendParameters),
-    setSendParameters: Pointer.fromFunction(_setSendParameters),
-    setCodecPreferences: Pointer.fromFunction(_setCodecPreferences),
+    getDirection: _getDirection,
+    replaceTrack: _replaceSendTrack,
+    dropSender: _dropSender,
+    isStopped: _isStopped,
+    mid: _mid,
+    setRecv: _setRecv,
+    setSend: _setSend,
+    dispose: _dispose,
+    createTransceiverInit: _createTransceiverInit,
+    addSendingEncodings: _addSendingEncodings,
+    getSendParameters: _getSendParameters,
+    setSendParameters: _setSendParameters,
+    setCodecPreferences: _setCodecPreferences,
   );
 }
 
 /// Creates a new [RtpTransceiverInit].
-Object _createTransceiverInit(int direction) {
+RtpTransceiverInit _createTransceiverInit(int direction) {
   return RtpTransceiverInit(TransceiverDirection.values[direction]);
 }
 
@@ -40,19 +39,19 @@ void _addSendingEncodings(Object init, Object encoding) {
 }
 
 /// Changes the receive direction of the provided [RtpTransceiver].
-Object _setRecv(Object transceiver, bool active) {
+Future<void> Function() _setRecv(Object transceiver, bool active) {
   transceiver as RtpTransceiver;
   return () => transceiver.setRecv(active);
 }
 
 /// Changes the send direction of the provided [RtpTransceiver].
-Object _setSend(Object transceiver, bool active) {
+Future<void> Function() _setSend(Object transceiver, bool active) {
   transceiver as RtpTransceiver;
   return () => transceiver.setSend(active);
 }
 
 /// Returns the current [TransceiverDirection] of the provided [RtpTransceiver].
-Object _getDirection(Object transceiver) {
+Future<int> Function() _getDirection(Object transceiver) {
   transceiver as RtpTransceiver;
   return () => transceiver.getDirection().then((d) => d.index);
 }
@@ -67,27 +66,16 @@ Pointer _mid(Object transceiver) {
   }
 }
 
-/// Returns the current [RtpTransceiver.sender]'s track of the provided
-/// [RtpTransceiver].
-Pointer _getSendTrack(Object transceiver) {
-  transceiver as RtpTransceiver;
-  if (transceiver.sender.track != null) {
-    return ForeignValue.fromHandle(transceiver.sender.track!).intoRustOwned();
-  } else {
-    return ForeignValue.none().intoRustOwned();
-  }
-}
-
 /// Replaces [RtpTransceiver.sender]'s [MediaStreamTrack] of the provided
 /// [RtpTransceiver] with a provided [MediaStreamTrack].
-Object _replaceSendTrack(Object transceiver, Object track) {
+Future<void> Function() _replaceSendTrack(Object transceiver, Object track) {
   transceiver as RtpTransceiver;
   track as MediaStreamTrack;
   return () => transceiver.sender.replaceTrack(track);
 }
 
 /// Drops the [RtpTransceiver.sender] of the provided [RtpTransceiver].
-Object _dropSender(Object transceiver) {
+Future Function() _dropSender(Object transceiver) {
   transceiver as RtpTransceiver;
   if (transceiver.sender.track == null) {
     return () => transceiver.sender.replaceTrack(null);
@@ -104,19 +92,20 @@ bool _isStopped(Object transceiver) {
 }
 
 /// Disposes of this [RtpTransceiver].
-Object _dispose(Object transceiver) {
+Future<void> Function() _dispose(Object transceiver) {
   transceiver as RtpTransceiver;
   return () => transceiver.dispose();
 }
 
 /// Returns [RtpParameters] from the provided [RtpTransceiver.sender].
-Object _getSendParameters(Object transceiver) {
+Future<RtpParameters> Function() _getSendParameters(Object transceiver) {
   transceiver as RtpTransceiver;
   return () => transceiver.sender.getParameters();
 }
 
 /// Sets [RtpParameters] into the provided [RtpTransceiver.sender].
-Object _setSendParameters(Object transceiver, Object parameters) {
+Future<void> Function() _setSendParameters(
+    Object transceiver, Object parameters) {
   transceiver as RtpTransceiver;
   parameters as RtpParameters;
   return () => transceiver.sender.setParameters(parameters);

--- a/flutter/lib/src/native/platform/transceiver.g.dart
+++ b/flutter/lib/src/native/platform/transceiver.g.dart
@@ -189,117 +189,117 @@ void registerFunction(
   );
 }
 
-Object _getDirectionProxy(Object a) {
+Object _getDirectionProxy(Object arg0) {
   try {
-    return _getDirection!(a);
+    return _getDirection!(arg0);
   } catch (e) {
     _transceiver__get_direction__set_error!(e);
     return 0;
   }
 }
 
-Object _replaceTrackProxy(Object a, Object b) {
+Object _replaceTrackProxy(Object arg0, Object arg1) {
   try {
-    return _replaceTrack!(a, b);
+    return _replaceTrack!(arg0, arg1);
   } catch (e) {
     _transceiver__replace_track__set_error!(e);
     return 0;
   }
 }
 
-Object _dropSenderProxy(Object a) {
+Object _dropSenderProxy(Object arg0) {
   try {
-    return _dropSender!(a);
+    return _dropSender!(arg0);
   } catch (e) {
     _transceiver__drop_sender__set_error!(e);
     return 0;
   }
 }
 
-bool _isStoppedProxy(Object a) {
+bool _isStoppedProxy(Object arg0) {
   try {
-    return _isStopped!(a);
+    return _isStopped!(arg0);
   } catch (e) {
     _transceiver__is_stopped__set_error!(e);
     return false;
   }
 }
 
-Pointer _midProxy(Object a) {
+Pointer _midProxy(Object arg0) {
   try {
-    return _mid!(a);
+    return _mid!(arg0);
   } catch (e) {
     _transceiver__mid__set_error!(e);
     return Pointer.fromAddress(0);
   }
 }
 
-Object _setRecvProxy(Object a, bool b) {
+Object _setRecvProxy(Object arg0, bool arg1) {
   try {
-    return _setRecv!(a, b);
+    return _setRecv!(arg0, arg1);
   } catch (e) {
     _transceiver__set_recv__set_error!(e);
     return 0;
   }
 }
 
-Object _setSendProxy(Object a, bool b) {
+Object _setSendProxy(Object arg0, bool arg1) {
   try {
-    return _setSend!(a, b);
+    return _setSend!(arg0, arg1);
   } catch (e) {
     _transceiver__set_send__set_error!(e);
     return 0;
   }
 }
 
-Object _disposeProxy(Object a) {
+Object _disposeProxy(Object arg0) {
   try {
-    return _dispose!(a);
+    return _dispose!(arg0);
   } catch (e) {
     _transceiver__dispose__set_error!(e);
     return 0;
   }
 }
 
-Object _createTransceiverInitProxy(int a) {
+Object _createTransceiverInitProxy(int arg0) {
   try {
-    return _createTransceiverInit!(a);
+    return _createTransceiverInit!(arg0);
   } catch (e) {
     _transceiver__create_transceiver_init__set_error!(e);
     return 0;
   }
 }
 
-void _addSendingEncodingsProxy(Object a, Object b) {
+void _addSendingEncodingsProxy(Object arg0, Object arg1) {
   try {
-    return _addSendingEncodings!(a, b);
+    return _addSendingEncodings!(arg0, arg1);
   } catch (e) {
     _transceiver__add_sending_encodings__set_error!(e);
     return;
   }
 }
 
-Object _getSendParametersProxy(Object a) {
+Object _getSendParametersProxy(Object arg0) {
   try {
-    return _getSendParameters!(a);
+    return _getSendParameters!(arg0);
   } catch (e) {
     _transceiver__get_send_parameters__set_error!(e);
     return 0;
   }
 }
 
-Object _setSendParametersProxy(Object a, Object b) {
+Object _setSendParametersProxy(Object arg0, Object arg1) {
   try {
-    return _setSendParameters!(a, b);
+    return _setSendParameters!(arg0, arg1);
   } catch (e) {
     _transceiver__set_send_parameters__set_error!(e);
     return 0;
   }
 }
 
-void _setCodecPreferencesProxy(Object a, Object b) {
+void _setCodecPreferencesProxy(Object arg0, Object arg1) {
   try {
-    return _setCodecPreferences!(a, b);
+    return _setCodecPreferences!(arg0, arg1);
   } catch (e) {
     _transceiver__set_codec_preferences__set_error!(e);
     return;

--- a/flutter/lib/src/native/platform/transceiver.g.dart
+++ b/flutter/lib/src/native/platform/transceiver.g.dart
@@ -4,44 +4,161 @@ import 'package:ffi/ffi.dart';
 
 import 'package:medea_jason/src/native/ffi/foreign_value.dart';
 
+typedef _ErrorSetterFnC = Void Function(Handle);
+typedef _ErrorSetterFnDart = void Function(Object);
+
+Object Function(Object)? _getDirection;
+Object Function(Object, Object)? _replaceTrack;
+Object Function(Object)? _dropSender;
+bool Function(Object)? _isStopped;
+Pointer Function(Object)? _mid;
+Object Function(Object, bool)? _setRecv;
+Object Function(Object, bool)? _setSend;
+Object Function(Object)? _dispose;
+Object Function(int)? _createTransceiverInit;
+void Function(Object, Object)? _addSendingEncodings;
+Object Function(Object)? _getSendParameters;
+Object Function(Object, Object)? _setSendParameters;
+void Function(Object, Object)? _setCodecPreferences;
+
+_ErrorSetterFnDart? _transceiver__get_direction__set_error;
+_ErrorSetterFnDart? _transceiver__replace_track__set_error;
+_ErrorSetterFnDart? _transceiver__drop_sender__set_error;
+_ErrorSetterFnDart? _transceiver__is_stopped__set_error;
+_ErrorSetterFnDart? _transceiver__mid__set_error;
+_ErrorSetterFnDart? _transceiver__set_recv__set_error;
+_ErrorSetterFnDart? _transceiver__set_send__set_error;
+_ErrorSetterFnDart? _transceiver__dispose__set_error;
+_ErrorSetterFnDart? _transceiver__create_transceiver_init__set_error;
+_ErrorSetterFnDart? _transceiver__add_sending_encodings__set_error;
+_ErrorSetterFnDart? _transceiver__get_send_parameters__set_error;
+_ErrorSetterFnDart? _transceiver__set_send_parameters__set_error;
+_ErrorSetterFnDart? _transceiver__set_codec_preferences__set_error;
+
 void registerFunction(
   DynamicLibrary dl, {
-  required Pointer<NativeFunction<Handle Function(Handle)>> getDirection,
-  required Pointer<NativeFunction<Pointer Function(Handle)>> getSendTrack,
-  required Pointer<NativeFunction<Handle Function(Handle, Handle)>>
-      replaceTrack,
-  required Pointer<NativeFunction<Handle Function(Handle)>> dropSender,
-  required Pointer<NativeFunction<Bool Function(Handle)>> isStopped,
-  required Pointer<NativeFunction<Pointer Function(Handle)>> mid,
-  required Pointer<NativeFunction<Handle Function(Handle, Bool)>> setRecv,
-  required Pointer<NativeFunction<Handle Function(Handle, Bool)>> setSend,
-  required Pointer<NativeFunction<Handle Function(Handle)>> dispose,
-  required Pointer<NativeFunction<Handle Function(Int64)>>
-      createTransceiverInit,
-  required Pointer<NativeFunction<Void Function(Handle, Handle)>>
-      addSendingEncodings,
-  required Pointer<NativeFunction<Handle Function(Handle)>> getSendParameters,
-  required Pointer<NativeFunction<Handle Function(Handle, Handle)>>
-      setSendParameters,
-  required Pointer<NativeFunction<Void Function(Handle, Handle)>>
-      setCodecPreferences,
+  required Object Function(Object) getDirection,
+  required Object Function(Object, Object) replaceTrack,
+  required Object Function(Object) dropSender,
+  required bool Function(Object) isStopped,
+  required Pointer Function(Object) mid,
+  required Object Function(Object, bool) setRecv,
+  required Object Function(Object, bool) setSend,
+  required Object Function(Object) dispose,
+  required Object Function(int) createTransceiverInit,
+  required void Function(Object, Object) addSendingEncodings,
+  required Object Function(Object) getSendParameters,
+  required Object Function(Object, Object) setSendParameters,
+  required void Function(Object, Object) setCodecPreferences,
 }) {
+  _getDirection = getDirection;
+  _replaceTrack = replaceTrack;
+  _dropSender = dropSender;
+  _isStopped = isStopped;
+  _mid = mid;
+  _setRecv = setRecv;
+  _setSend = setSend;
+  _dispose = dispose;
+  _createTransceiverInit = createTransceiverInit;
+  _addSendingEncodings = addSendingEncodings;
+  _getSendParameters = getSendParameters;
+  _setSendParameters = setSendParameters;
+  _setCodecPreferences = setCodecPreferences;
+
+  _transceiver__get_direction__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'transceiver__get_direction__set_error');
+  _transceiver__replace_track__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'transceiver__replace_track__set_error');
+  _transceiver__drop_sender__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'transceiver__drop_sender__set_error');
+  _transceiver__is_stopped__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'transceiver__is_stopped__set_error');
+  _transceiver__mid__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'transceiver__mid__set_error');
+  _transceiver__set_recv__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'transceiver__set_recv__set_error');
+  _transceiver__set_send__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'transceiver__set_send__set_error');
+  _transceiver__dispose__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'transceiver__dispose__set_error');
+  _transceiver__create_transceiver_init__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'transceiver__create_transceiver_init__set_error');
+  _transceiver__add_sending_encodings__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'transceiver__add_sending_encodings__set_error');
+  _transceiver__get_send_parameters__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'transceiver__get_send_parameters__set_error');
+  _transceiver__set_send_parameters__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'transceiver__set_send_parameters__set_error');
+  _transceiver__set_codec_preferences__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'transceiver__set_codec_preferences__set_error');
+
+  Pointer<NativeFunction<Handle Function(Handle)>> getDirection_native =
+      Pointer.fromFunction(
+    _getDirectionProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Handle, Handle)>> replaceTrack_native =
+      Pointer.fromFunction(
+    _replaceTrackProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Handle)>> dropSender_native =
+      Pointer.fromFunction(
+    _dropSenderProxy,
+  );
+  Pointer<NativeFunction<Bool Function(Handle)>> isStopped_native =
+      Pointer.fromFunction(_isStoppedProxy, false);
+  Pointer<NativeFunction<Pointer Function(Handle)>> mid_native =
+      Pointer.fromFunction(
+    _midProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Handle, Bool)>> setRecv_native =
+      Pointer.fromFunction(
+    _setRecvProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Handle, Bool)>> setSend_native =
+      Pointer.fromFunction(
+    _setSendProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Handle)>> dispose_native =
+      Pointer.fromFunction(
+    _disposeProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Int64)>> createTransceiverInit_native =
+      Pointer.fromFunction(
+    _createTransceiverInitProxy,
+  );
+  Pointer<NativeFunction<Void Function(Handle, Handle)>>
+      addSendingEncodings_native = Pointer.fromFunction(
+    _addSendingEncodingsProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Handle)>> getSendParameters_native =
+      Pointer.fromFunction(
+    _getSendParametersProxy,
+  );
+  Pointer<NativeFunction<Handle Function(Handle, Handle)>>
+      setSendParameters_native = Pointer.fromFunction(
+    _setSendParametersProxy,
+  );
+  Pointer<NativeFunction<Void Function(Handle, Handle)>>
+      setCodecPreferences_native = Pointer.fromFunction(
+    _setCodecPreferencesProxy,
+  );
+
   dl.lookupFunction<
-      Void Function(
-          Pointer,
-          Pointer,
-          Pointer,
-          Pointer,
-          Pointer,
-          Pointer,
-          Pointer,
-          Pointer,
-          Pointer,
-          Pointer,
-          Pointer,
-          Pointer,
-          Pointer,
-          Pointer),
+      Void Function(Pointer, Pointer, Pointer, Pointer, Pointer, Pointer,
+          Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer),
       void Function(
           Pointer,
           Pointer,
@@ -55,21 +172,136 @@ void registerFunction(
           Pointer,
           Pointer,
           Pointer,
-          Pointer,
           Pointer)>('register_transceiver')(
-    getDirection,
-    getSendTrack,
-    replaceTrack,
-    dropSender,
-    isStopped,
-    mid,
-    setRecv,
-    setSend,
-    dispose,
-    createTransceiverInit,
-    addSendingEncodings,
-    getSendParameters,
-    setSendParameters,
-    setCodecPreferences,
+    getDirection_native,
+    replaceTrack_native,
+    dropSender_native,
+    isStopped_native,
+    mid_native,
+    setRecv_native,
+    setSend_native,
+    dispose_native,
+    createTransceiverInit_native,
+    addSendingEncodings_native,
+    getSendParameters_native,
+    setSendParameters_native,
+    setCodecPreferences_native,
   );
+}
+
+Object _getDirectionProxy(Object a) {
+  try {
+    return _getDirection!(a);
+  } catch (e) {
+    _transceiver__get_direction__set_error!(e);
+    return 0;
+  }
+}
+
+Object _replaceTrackProxy(Object a, Object b) {
+  try {
+    return _replaceTrack!(a, b);
+  } catch (e) {
+    _transceiver__replace_track__set_error!(e);
+    return 0;
+  }
+}
+
+Object _dropSenderProxy(Object a) {
+  try {
+    return _dropSender!(a);
+  } catch (e) {
+    _transceiver__drop_sender__set_error!(e);
+    return 0;
+  }
+}
+
+bool _isStoppedProxy(Object a) {
+  try {
+    return _isStopped!(a);
+  } catch (e) {
+    _transceiver__is_stopped__set_error!(e);
+    return false;
+  }
+}
+
+Pointer _midProxy(Object a) {
+  try {
+    return _mid!(a);
+  } catch (e) {
+    _transceiver__mid__set_error!(e);
+    return Pointer.fromAddress(0);
+  }
+}
+
+Object _setRecvProxy(Object a, bool b) {
+  try {
+    return _setRecv!(a, b);
+  } catch (e) {
+    _transceiver__set_recv__set_error!(e);
+    return 0;
+  }
+}
+
+Object _setSendProxy(Object a, bool b) {
+  try {
+    return _setSend!(a, b);
+  } catch (e) {
+    _transceiver__set_send__set_error!(e);
+    return 0;
+  }
+}
+
+Object _disposeProxy(Object a) {
+  try {
+    return _dispose!(a);
+  } catch (e) {
+    _transceiver__dispose__set_error!(e);
+    return 0;
+  }
+}
+
+Object _createTransceiverInitProxy(int a) {
+  try {
+    return _createTransceiverInit!(a);
+  } catch (e) {
+    _transceiver__create_transceiver_init__set_error!(e);
+    return 0;
+  }
+}
+
+void _addSendingEncodingsProxy(Object a, Object b) {
+  try {
+    return _addSendingEncodings!(a, b);
+  } catch (e) {
+    _transceiver__add_sending_encodings__set_error!(e);
+    return;
+  }
+}
+
+Object _getSendParametersProxy(Object a) {
+  try {
+    return _getSendParameters!(a);
+  } catch (e) {
+    _transceiver__get_send_parameters__set_error!(e);
+    return 0;
+  }
+}
+
+Object _setSendParametersProxy(Object a, Object b) {
+  try {
+    return _setSendParameters!(a, b);
+  } catch (e) {
+    _transceiver__set_send_parameters__set_error!(e);
+    return 0;
+  }
+}
+
+void _setCodecPreferencesProxy(Object a, Object b) {
+  try {
+    return _setCodecPreferences!(a, b);
+  } catch (e) {
+    _transceiver__set_codec_preferences__set_error!(e);
+    return;
+  }
 }

--- a/flutter/lib/src/native/platform/transport.dart
+++ b/flutter/lib/src/native/platform/transport.dart
@@ -61,7 +61,8 @@ class MockWebSocket {
   ///
   /// Subscribes to the created [WebSocket] messages with the specified
   /// [onMessage] and [onClose] callbacks.
-  static Object connect(Pointer<Utf8> addr, Object onMessage, Object onClose) {
+  static Future<WebSocket> Function() connect(
+      Pointer<Utf8> addr, Object onMessage, Object onClose) {
     onMessage as Function;
     onClose as Function;
     return () async {

--- a/flutter/lib/src/native/platform/transport.dart
+++ b/flutter/lib/src/native/platform/transport.dart
@@ -15,20 +15,20 @@ void registerFunctions(DynamicLibrary dl) {
   if (mockable) {
     bridge.registerFunction(
       dl,
-      connect: Pointer.fromFunction(MockWebSocket.connect),
-      send: Pointer.fromFunction(_send),
-      close: Pointer.fromFunction(_close),
-      closeCode: Pointer.fromFunction(_closeCode, 0),
-      closeReason: Pointer.fromFunction(_closeReason),
+      connect: MockWebSocket.connect,
+      send: _send,
+      close: _close,
+      closeCode: _closeCode,
+      closeReason: _closeReason,
     );
   } else {
     bridge.registerFunction(
       dl,
-      connect: Pointer.fromFunction(_connect),
-      send: Pointer.fromFunction(_send),
-      close: Pointer.fromFunction(_close),
-      closeCode: Pointer.fromFunction(_closeCode, 0),
-      closeReason: Pointer.fromFunction(_closeReason),
+      connect: _connect,
+      send: _send,
+      close: _close,
+      closeCode: _closeCode,
+      closeReason: _closeReason,
     );
   }
 }
@@ -98,7 +98,8 @@ class MockWebSocket {
 ///
 /// Subscribes to the created [WebSocket] messages with the given [onMessage]
 /// and [onClose] callbacks.
-Object _connect(Pointer<Utf8> addr, Object onMessage, Object onClose) {
+Future<WebSocket> Function() _connect(
+    Pointer<Utf8> addr, Object onMessage, Object onClose) {
   onMessage as Function;
   onClose as Function;
   return () async {

--- a/flutter/lib/src/native/platform/transport.g.dart
+++ b/flutter/lib/src/native/platform/transport.g.dart
@@ -4,25 +4,123 @@ import 'package:ffi/ffi.dart';
 
 import 'package:medea_jason/src/native/ffi/foreign_value.dart';
 
+typedef _ErrorSetterFnC = Void Function(Handle);
+typedef _ErrorSetterFnDart = void Function(Object);
+
+Object Function(Pointer<Utf8>, Object, Object)? _connect;
+void Function(Object, Pointer<Utf8>)? _send;
+void Function(Object, int, Pointer<Utf8>)? _close;
+int Function(Object)? _closeCode;
+Pointer<Utf8> Function(Object)? _closeReason;
+
+_ErrorSetterFnDart? _transport__connect__set_error;
+_ErrorSetterFnDart? _transport__send__set_error;
+_ErrorSetterFnDart? _transport__close__set_error;
+_ErrorSetterFnDart? _transport__close_code__set_error;
+_ErrorSetterFnDart? _transport__close_reason__set_error;
+
 void registerFunction(
   DynamicLibrary dl, {
-  required Pointer<
-          NativeFunction<Handle Function(Pointer<Utf8>, Handle, Handle)>>
-      connect,
-  required Pointer<NativeFunction<Void Function(Handle, Pointer<Utf8>)>> send,
-  required Pointer<NativeFunction<Void Function(Handle, Int32, Pointer<Utf8>)>>
-      close,
-  required Pointer<NativeFunction<Int32 Function(Handle)>> closeCode,
-  required Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> closeReason,
+  required Object Function(Pointer<Utf8>, Object, Object) connect,
+  required void Function(Object, Pointer<Utf8>) send,
+  required void Function(Object, int, Pointer<Utf8>) close,
+  required int Function(Object) closeCode,
+  required Pointer<Utf8> Function(Object) closeReason,
 }) {
+  _connect = connect;
+  _send = send;
+  _close = close;
+  _closeCode = closeCode;
+  _closeReason = closeReason;
+
+  _transport__connect__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'transport__connect__set_error');
+  _transport__send__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'transport__send__set_error');
+  _transport__close__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'transport__close__set_error');
+  _transport__close_code__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'transport__close_code__set_error');
+  _transport__close_reason__set_error =
+      dl.lookupFunction<_ErrorSetterFnC, _ErrorSetterFnDart>(
+          'transport__close_reason__set_error');
+
+  Pointer<NativeFunction<Handle Function(Pointer<Utf8>, Handle, Handle)>>
+      connect_native = Pointer.fromFunction(
+    _connectProxy,
+  );
+  Pointer<NativeFunction<Void Function(Handle, Pointer<Utf8>)>> send_native =
+      Pointer.fromFunction(
+    _sendProxy,
+  );
+  Pointer<NativeFunction<Void Function(Handle, Int32, Pointer<Utf8>)>>
+      close_native = Pointer.fromFunction(
+    _closeProxy,
+  );
+  Pointer<NativeFunction<Int32 Function(Handle)>> closeCode_native =
+      Pointer.fromFunction(_closeCodeProxy, 0);
+  Pointer<NativeFunction<Pointer<Utf8> Function(Handle)>> closeReason_native =
+      Pointer.fromFunction(
+    _closeReasonProxy,
+  );
+
   dl.lookupFunction<
       Void Function(Pointer, Pointer, Pointer, Pointer, Pointer),
       void Function(
           Pointer, Pointer, Pointer, Pointer, Pointer)>('register_transport')(
-    connect,
-    send,
-    close,
-    closeCode,
-    closeReason,
+    connect_native,
+    send_native,
+    close_native,
+    closeCode_native,
+    closeReason_native,
   );
+}
+
+Object _connectProxy(Pointer<Utf8> a, Object b, Object c) {
+  try {
+    return _connect!(a, b, c);
+  } catch (e) {
+    _transport__connect__set_error!(e);
+    return 0;
+  }
+}
+
+void _sendProxy(Object a, Pointer<Utf8> b) {
+  try {
+    return _send!(a, b);
+  } catch (e) {
+    _transport__send__set_error!(e);
+    return;
+  }
+}
+
+void _closeProxy(Object a, int b, Pointer<Utf8> c) {
+  try {
+    return _close!(a, b, c);
+  } catch (e) {
+    _transport__close__set_error!(e);
+    return;
+  }
+}
+
+int _closeCodeProxy(Object a) {
+  try {
+    return _closeCode!(a);
+  } catch (e) {
+    _transport__close_code__set_error!(e);
+    return 0;
+  }
+}
+
+Pointer<Utf8> _closeReasonProxy(Object a) {
+  try {
+    return _closeReason!(a);
+  } catch (e) {
+    _transport__close_reason__set_error!(e);
+    return Pointer.fromAddress(0);
+  }
 }

--- a/flutter/lib/src/native/platform/transport.g.dart
+++ b/flutter/lib/src/native/platform/transport.g.dart
@@ -80,45 +80,45 @@ void registerFunction(
   );
 }
 
-Object _connectProxy(Pointer<Utf8> a, Object b, Object c) {
+Object _connectProxy(Pointer<Utf8> arg0, Object arg1, Object arg2) {
   try {
-    return _connect!(a, b, c);
+    return _connect!(arg0, arg1, arg2);
   } catch (e) {
     _transport__connect__set_error!(e);
     return 0;
   }
 }
 
-void _sendProxy(Object a, Pointer<Utf8> b) {
+void _sendProxy(Object arg0, Pointer<Utf8> arg1) {
   try {
-    return _send!(a, b);
+    return _send!(arg0, arg1);
   } catch (e) {
     _transport__send__set_error!(e);
     return;
   }
 }
 
-void _closeProxy(Object a, int b, Pointer<Utf8> c) {
+void _closeProxy(Object arg0, int arg1, Pointer<Utf8> arg2) {
   try {
-    return _close!(a, b, c);
+    return _close!(arg0, arg1, arg2);
   } catch (e) {
     _transport__close__set_error!(e);
     return;
   }
 }
 
-int _closeCodeProxy(Object a) {
+int _closeCodeProxy(Object arg0) {
   try {
-    return _closeCode!(a);
+    return _closeCode!(arg0);
   } catch (e) {
     _transport__close_code__set_error!(e);
     return 0;
   }
 }
 
-Pointer<Utf8> _closeReasonProxy(Object a) {
+Pointer<Utf8> _closeReasonProxy(Object arg0) {
   try {
-    return _closeReason!(a);
+    return _closeReason!(arg0);
   } catch (e) {
     _transport__close_reason__set_error!(e);
     return Pointer.fromAddress(0);

--- a/src/api/dart/utils/err.rs
+++ b/src/api/dart/utils/err.rs
@@ -147,10 +147,10 @@ impl From<platform::Error> for DartError {
     }
 }
 
-#[allow(clippy::fallible_impl_from)]
+#[allow(clippy::fallible_impl_from)] // intentional
 impl From<StateError> for DartError {
     fn from(err: StateError) -> Self {
-        #[allow(clippy::unwrap_used)]
+        #[allow(clippy::unwrap_used)] // intentional
         let exception = unsafe {
             exception::new_state_error(string_into_c_str(err.message()))
         }
@@ -160,10 +160,10 @@ impl From<StateError> for DartError {
     }
 }
 
-#[allow(clippy::fallible_impl_from)]
+#[allow(clippy::fallible_impl_from)] // intentional
 impl From<LocalMediaInitException> for DartError {
     fn from(err: LocalMediaInitException) -> Self {
-        #[allow(clippy::unwrap_used)]
+        #[allow(clippy::unwrap_used)] // intentional
         let exception = unsafe {
             exception::new_local_media_init_exception(
                 err.kind() as i64,
@@ -178,10 +178,10 @@ impl From<LocalMediaInitException> for DartError {
     }
 }
 
-#[allow(clippy::fallible_impl_from)]
+#[allow(clippy::fallible_impl_from)] // intentional
 impl From<EnumerateDevicesException> for DartError {
     fn from(err: EnumerateDevicesException) -> Self {
-        #[allow(clippy::unwrap_used)]
+        #[allow(clippy::unwrap_used)] // intentional
         let exception = unsafe {
             exception::new_enumerate_devices_exception(
                 err.cause().into(),
@@ -194,10 +194,10 @@ impl From<EnumerateDevicesException> for DartError {
     }
 }
 
-#[allow(clippy::fallible_impl_from)]
+#[allow(clippy::fallible_impl_from)] // intentional
 impl From<InvalidOutputAudioDeviceIdException> for DartError {
     fn from(err: InvalidOutputAudioDeviceIdException) -> Self {
-        #[allow(clippy::unwrap_used)]
+        #[allow(clippy::unwrap_used)] // intentional
         let exception = unsafe {
             exception::new_invalid_output_audio_device_id_exception(
                 string_into_c_str(err.trace()),
@@ -209,10 +209,10 @@ impl From<InvalidOutputAudioDeviceIdException> for DartError {
     }
 }
 
-#[allow(clippy::fallible_impl_from)]
+#[allow(clippy::fallible_impl_from)] // intentional
 impl From<MicVolumeException> for DartError {
     fn from(err: MicVolumeException) -> Self {
-        #[allow(clippy::unwrap_used)]
+        #[allow(clippy::unwrap_used)] // intentional
         let exception = unsafe {
             exception::new_mic_volume_exception(
                 err.cause().into(),
@@ -225,10 +225,10 @@ impl From<MicVolumeException> for DartError {
     }
 }
 
-#[allow(clippy::fallible_impl_from)]
+#[allow(clippy::fallible_impl_from)] // intentional
 impl From<FormatException> for DartError {
     fn from(err: FormatException) -> Self {
-        #[allow(clippy::unwrap_used)]
+        #[allow(clippy::unwrap_used)] // intentional
         let exception = unsafe {
             exception::new_format_exception(string_into_c_str(err.message()))
         }
@@ -238,10 +238,10 @@ impl From<FormatException> for DartError {
     }
 }
 
-#[allow(clippy::fallible_impl_from)]
+#[allow(clippy::fallible_impl_from)] // intentional
 impl From<RpcClientException> for DartError {
     fn from(err: RpcClientException) -> Self {
-        #[allow(clippy::unwrap_used)]
+        #[allow(clippy::unwrap_used)] // intentional
         let exception = unsafe {
             exception::new_rpc_client_exception(
                 err.kind() as i64,
@@ -256,10 +256,10 @@ impl From<RpcClientException> for DartError {
     }
 }
 
-#[allow(clippy::fallible_impl_from)]
+#[allow(clippy::fallible_impl_from)] // intentional
 impl From<MediaStateTransitionException> for DartError {
     fn from(err: MediaStateTransitionException) -> Self {
-        #[allow(clippy::unwrap_used)]
+        #[allow(clippy::unwrap_used)] // intentional
         let exception = unsafe {
             exception::new_media_state_transition_exception(
                 string_into_c_str(err.message()),
@@ -273,10 +273,10 @@ impl From<MediaStateTransitionException> for DartError {
     }
 }
 
-#[allow(clippy::fallible_impl_from)]
+#[allow(clippy::fallible_impl_from)] // intentional
 impl From<InternalException> for DartError {
     fn from(err: InternalException) -> Self {
-        #[allow(clippy::unwrap_used)]
+        #[allow(clippy::unwrap_used)] // intentional
         let exception = unsafe {
             exception::new_internal_exception(
                 string_into_c_str(err.message()),
@@ -290,10 +290,10 @@ impl From<InternalException> for DartError {
     }
 }
 
-#[allow(clippy::fallible_impl_from)]
+#[allow(clippy::fallible_impl_from)] // intentional
 impl From<MediaSettingsUpdateException> for DartError {
     fn from(err: MediaSettingsUpdateException) -> Self {
-        #[allow(clippy::unwrap_used)]
+        #[allow(clippy::unwrap_used)] // intentional
         let exception = unsafe {
             exception::new_media_settings_update_exception(
                 string_into_c_str(err.message()),

--- a/src/api/dart/utils/err.rs
+++ b/src/api/dart/utils/err.rs
@@ -155,8 +155,10 @@ impl From<platform::Error> for DartError {
     }
 }
 
+#[allow(clippy::fallible_impl_from)]
 impl From<StateError> for DartError {
     fn from(err: StateError) -> Self {
+        #[allow(clippy::unwrap_used)]
         let exception = unsafe {
             exception::new_state_error(string_into_c_str(err.message()))
         }
@@ -166,8 +168,10 @@ impl From<StateError> for DartError {
     }
 }
 
+#[allow(clippy::fallible_impl_from)]
 impl From<LocalMediaInitException> for DartError {
     fn from(err: LocalMediaInitException) -> Self {
+        #[allow(clippy::unwrap_used)]
         let exception = unsafe {
             exception::new_local_media_init_exception(
                 err.kind() as i64,
@@ -182,8 +186,10 @@ impl From<LocalMediaInitException> for DartError {
     }
 }
 
+#[allow(clippy::fallible_impl_from)]
 impl From<EnumerateDevicesException> for DartError {
     fn from(err: EnumerateDevicesException) -> Self {
+        #[allow(clippy::unwrap_used)]
         let exception = unsafe {
             exception::new_enumerate_devices_exception(
                 err.cause().into(),
@@ -196,8 +202,10 @@ impl From<EnumerateDevicesException> for DartError {
     }
 }
 
+#[allow(clippy::fallible_impl_from)]
 impl From<InvalidOutputAudioDeviceIdException> for DartError {
     fn from(err: InvalidOutputAudioDeviceIdException) -> Self {
+        #[allow(clippy::unwrap_used)]
         let exception = unsafe {
             exception::new_invalid_output_audio_device_id_exception(
                 string_into_c_str(err.trace()),
@@ -209,8 +217,10 @@ impl From<InvalidOutputAudioDeviceIdException> for DartError {
     }
 }
 
+#[allow(clippy::fallible_impl_from)]
 impl From<MicVolumeException> for DartError {
     fn from(err: MicVolumeException) -> Self {
+        #[allow(clippy::unwrap_used)]
         let exception = unsafe {
             exception::new_mic_volume_exception(
                 err.cause().into(),
@@ -223,8 +233,10 @@ impl From<MicVolumeException> for DartError {
     }
 }
 
+#[allow(clippy::fallible_impl_from)]
 impl From<FormatException> for DartError {
     fn from(err: FormatException) -> Self {
+        #[allow(clippy::unwrap_used)]
         let exception = unsafe {
             exception::new_format_exception(string_into_c_str(err.message()))
         }
@@ -234,8 +246,10 @@ impl From<FormatException> for DartError {
     }
 }
 
+#[allow(clippy::fallible_impl_from)]
 impl From<RpcClientException> for DartError {
     fn from(err: RpcClientException) -> Self {
+        #[allow(clippy::unwrap_used)]
         let exception = unsafe {
             exception::new_rpc_client_exception(
                 err.kind() as i64,
@@ -250,8 +264,10 @@ impl From<RpcClientException> for DartError {
     }
 }
 
+#[allow(clippy::fallible_impl_from)]
 impl From<MediaStateTransitionException> for DartError {
     fn from(err: MediaStateTransitionException) -> Self {
+        #[allow(clippy::unwrap_used)]
         let exception = unsafe {
             exception::new_media_state_transition_exception(
                 string_into_c_str(err.message()),
@@ -265,8 +281,10 @@ impl From<MediaStateTransitionException> for DartError {
     }
 }
 
+#[allow(clippy::fallible_impl_from)]
 impl From<InternalException> for DartError {
     fn from(err: InternalException) -> Self {
+        #[allow(clippy::unwrap_used)]
         let exception = unsafe {
             exception::new_internal_exception(
                 string_into_c_str(err.message()),
@@ -280,8 +298,10 @@ impl From<InternalException> for DartError {
     }
 }
 
+#[allow(clippy::fallible_impl_from)]
 impl From<MediaSettingsUpdateException> for DartError {
     fn from(err: MediaSettingsUpdateException) -> Self {
+        #[allow(clippy::unwrap_used)]
         let exception = unsafe {
             exception::new_media_settings_update_exception(
                 string_into_c_str(err.message()),

--- a/src/api/dart/utils/err.rs
+++ b/src/api/dart/utils/err.rs
@@ -110,23 +110,15 @@ mod exception {
         ) -> Result<Dart_Handle, Error>;
 
         /// Returns a new Dart `NativePanicException`.
-        ///
-        /// Returned [`Dart_Handle`] will be recognized by Dart runtime as an
-        /// error, so `Dart_IsError` function will return `true` on the returned
-        /// [`Dart_Handle`].
-        pub fn throw_panic_exception() -> Result<Dart_Handle, Error>;
+        pub fn new_panic_exception() -> Result<Dart_Handle, Error>;
     }
 }
 
 /// Creates and returns a new Dart `NativePanicException`.
-///
-/// Returned [`Dart_Handle`] will be recognized by Dart runtime as an error, so
-/// `Dart_IsError` function will return `true` on the returned [`Dart_Handle`].
 #[must_use]
 pub unsafe fn new_panic_error() -> Dart_Handle {
-    // asdasdasd TODO:
-    // unsafe { exception::throw_panic_exception() }
-    unimplemented!()
+    #[allow(clippy::unwrap_used)]
+    unsafe { exception::new_panic_exception() }.unwrap()
 }
 
 /// An error that can be returned from Rust to Dart.

--- a/src/api/dart/utils/err.rs
+++ b/src/api/dart/utils/err.rs
@@ -27,7 +27,7 @@ mod exception {
     use dart_sys::Dart_Handle;
     use libc::c_char;
 
-    use crate::api::DartValue;
+    use crate::{api::DartValue, platform::Error};
 
     use super::DartError;
 
@@ -36,14 +36,16 @@ mod exception {
         /// Returns a new Dart [`StateError`] with the provided message.
         ///
         /// [`StateError`]: https://api.dart.dev/dart-core/StateError-class.html
-        pub fn new_state_error(message: ptr::NonNull<c_char>) -> Dart_Handle;
+        pub fn new_state_error(
+            message: ptr::NonNull<c_char>,
+        ) -> Result<Dart_Handle, Error>;
 
         /// Returns a new Dart [`FormatException`][1] with the provided message.
         ///
         /// [1]: https://api.dart.dev/dart-core/FormatException-class.html
         pub fn new_format_exception(
             message: ptr::NonNull<c_char>,
-        ) -> Dart_Handle;
+        ) -> Result<Dart_Handle, Error>;
 
         /// Returns a new Dart [`LocalMediaInitException`] with the provided
         /// error `kind`, `message`, `cause` and `stacktrace`.
@@ -52,14 +54,14 @@ mod exception {
             message: ptr::NonNull<c_char>,
             cause: DartValue,
             stacktrace: ptr::NonNull<c_char>,
-        ) -> Dart_Handle;
+        ) -> Result<Dart_Handle, Error>;
 
         /// Returns a new Dart [`EnumerateDevicesException`] with the provided
         /// error `cause` and `stacktrace`.
         pub fn new_enumerate_devices_exception(
             cause: DartError,
             stacktrace: ptr::NonNull<c_char>,
-        ) -> Dart_Handle;
+        ) -> Result<Dart_Handle, Error>;
 
         /// Returns a new Dart [`RpcClientException`] with the provided error
         /// `kind`, `message`, `cause` and `stacktrace`.
@@ -68,7 +70,7 @@ mod exception {
             message: ptr::NonNull<c_char>,
             cause: DartValue,
             stacktrace: ptr::NonNull<c_char>,
-        ) -> Dart_Handle;
+        ) -> Result<Dart_Handle, Error>;
 
         /// Returns a new Dart [`MediaStateTransitionException`] with the
         /// provided error `message` and `stacktrace`.
@@ -76,7 +78,7 @@ mod exception {
             message: ptr::NonNull<c_char>,
             stacktrace: ptr::NonNull<c_char>,
             kind: i64,
-        ) -> Dart_Handle;
+        ) -> Result<Dart_Handle, Error>;
 
         /// Returns a new Dart [`InternalException`] with the provided error
         /// `message`, `cause` and `stacktrace`.
@@ -84,7 +86,7 @@ mod exception {
             message: ptr::NonNull<c_char>,
             cause: DartValue,
             stacktrace: ptr::NonNull<c_char>,
-        ) -> Dart_Handle;
+        ) -> Result<Dart_Handle, Error>;
 
         /// Returns a new Dart [`MediaSettingsUpdateException`] with the
         /// provided error `message`, `cause` and `rolled_back` property.
@@ -92,27 +94,27 @@ mod exception {
             message: ptr::NonNull<c_char>,
             cause: DartError,
             rolled_back: bool,
-        ) -> Dart_Handle;
+        ) -> Result<Dart_Handle, Error>;
 
         /// Returns a new Dart [`InvalidOutputAudioDeviceIdException`] with the
         /// provided `trace` property.
         pub fn new_invalid_output_audio_device_id_exception(
             trace: ptr::NonNull<c_char>,
-        ) -> Dart_Handle;
+        ) -> Result<Dart_Handle, Error>;
 
         /// Returns a new Dart [`MicVolumeException`] with the provided `cause`
         /// and `trace` properties.
         pub fn new_mic_volume_exception(
             cause: DartError,
             trace: ptr::NonNull<c_char>,
-        ) -> Dart_Handle;
+        ) -> Result<Dart_Handle, Error>;
 
         /// Returns a new Dart `NativePanicException`.
         ///
         /// Returned [`Dart_Handle`] will be recognized by Dart runtime as an
         /// error, so `Dart_IsError` function will return `true` on the returned
         /// [`Dart_Handle`].
-        pub fn throw_panic_exception() -> Dart_Handle;
+        pub fn throw_panic_exception() -> Result<Dart_Handle, Error>;
     }
 }
 
@@ -122,7 +124,9 @@ mod exception {
 /// `Dart_IsError` function will return `true` on the returned [`Dart_Handle`].
 #[must_use]
 pub unsafe fn new_panic_error() -> Dart_Handle {
-    unsafe { exception::throw_panic_exception() }
+    // asdasdasd TODO:
+    // unsafe { exception::throw_panic_exception() }
+    unimplemented!()
 }
 
 /// An error that can be returned from Rust to Dart.
@@ -153,114 +157,140 @@ impl From<platform::Error> for DartError {
 
 impl From<StateError> for DartError {
     fn from(err: StateError) -> Self {
-        unsafe {
-            Self::new(exception::new_state_error(string_into_c_str(
-                err.message(),
-            )))
+        let exception = unsafe {
+            exception::new_state_error(string_into_c_str(err.message()))
         }
+        .unwrap();
+
+        Self::new(exception)
     }
 }
 
 impl From<LocalMediaInitException> for DartError {
     fn from(err: LocalMediaInitException) -> Self {
-        unsafe {
-            Self::new(exception::new_local_media_init_exception(
+        let exception = unsafe {
+            exception::new_local_media_init_exception(
                 err.kind() as i64,
                 string_into_c_str(err.message()),
                 err.cause().map(Self::from).into(),
                 string_into_c_str(err.trace()),
-            ))
+            )
         }
+        .unwrap();
+
+        Self::new(exception)
     }
 }
 
 impl From<EnumerateDevicesException> for DartError {
     fn from(err: EnumerateDevicesException) -> Self {
-        unsafe {
-            Self::new(exception::new_enumerate_devices_exception(
+        let exception = unsafe {
+            exception::new_enumerate_devices_exception(
                 err.cause().into(),
                 string_into_c_str(err.trace()),
-            ))
+            )
         }
+        .unwrap();
+
+        Self::new(exception)
     }
 }
 
 impl From<InvalidOutputAudioDeviceIdException> for DartError {
     fn from(err: InvalidOutputAudioDeviceIdException) -> Self {
-        unsafe {
-            Self::new(exception::new_invalid_output_audio_device_id_exception(
+        let exception = unsafe {
+            exception::new_invalid_output_audio_device_id_exception(
                 string_into_c_str(err.trace()),
-            ))
+            )
         }
+        .unwrap();
+
+        Self::new(exception)
     }
 }
 
 impl From<MicVolumeException> for DartError {
     fn from(err: MicVolumeException) -> Self {
-        unsafe {
-            Self::new(exception::new_mic_volume_exception(
+        let exception = unsafe {
+            exception::new_mic_volume_exception(
                 err.cause().into(),
                 string_into_c_str(err.trace()),
-            ))
+            )
         }
+        .unwrap();
+
+        Self::new(exception)
     }
 }
 
 impl From<FormatException> for DartError {
     fn from(err: FormatException) -> Self {
-        unsafe {
-            Self::new(exception::new_format_exception(string_into_c_str(
-                err.message(),
-            )))
+        let exception = unsafe {
+            exception::new_format_exception(string_into_c_str(err.message()))
         }
+        .unwrap();
+
+        Self::new(exception)
     }
 }
 
 impl From<RpcClientException> for DartError {
     fn from(err: RpcClientException) -> Self {
-        unsafe {
-            Self::new(exception::new_rpc_client_exception(
+        let exception = unsafe {
+            exception::new_rpc_client_exception(
                 err.kind() as i64,
                 string_into_c_str(err.message()),
                 err.cause().map(Self::from).into(),
                 string_into_c_str(err.trace()),
-            ))
+            )
         }
+        .unwrap();
+
+        Self::new(exception)
     }
 }
 
 impl From<MediaStateTransitionException> for DartError {
     fn from(err: MediaStateTransitionException) -> Self {
-        unsafe {
-            Self::new(exception::new_media_state_transition_exception(
+        let exception = unsafe {
+            exception::new_media_state_transition_exception(
                 string_into_c_str(err.message()),
                 string_into_c_str(err.trace()),
                 err.kind() as i64,
-            ))
+            )
         }
+        .unwrap();
+
+        Self::new(exception)
     }
 }
 
 impl From<InternalException> for DartError {
     fn from(err: InternalException) -> Self {
-        unsafe {
-            Self::new(exception::new_internal_exception(
+        let exception = unsafe {
+            exception::new_internal_exception(
                 string_into_c_str(err.message()),
                 err.cause().map(Self::from).into(),
                 string_into_c_str(err.trace()),
-            ))
+            )
         }
+        .unwrap();
+
+        Self::new(exception)
     }
 }
 
 impl From<MediaSettingsUpdateException> for DartError {
     fn from(err: MediaSettingsUpdateException) -> Self {
-        unsafe {
-            Self::new(exception::new_media_settings_update_exception(
+        let exception = unsafe {
+            exception::new_media_settings_update_exception(
                 string_into_c_str(err.message()),
                 err.cause(),
                 err.rolled_back(),
-            ))
+            )
         }
+        .unwrap();
+
+        Self::new(exception)
     }
 }

--- a/src/platform/dart/codec_capability.rs
+++ b/src/platform/dart/codec_capability.rs
@@ -92,7 +92,7 @@ impl CodecCapability {
     /// implementation.
     ///
     /// [2]: https://w3.org/TR/webrtc#dom-rtcrtpcodeccapability-mimetype
-    #[allow(clippy::unwrap_in_result)]
+    #[allow(clippy::unwrap_in_result)] // intentional
     pub fn mime_type(&self) -> Result<String, Error> {
         let mime_type =
             unsafe { codec_capability::mime_type(self.0.get()) }.unwrap();

--- a/src/platform/dart/codec_capability.rs
+++ b/src/platform/dart/codec_capability.rs
@@ -92,6 +92,7 @@ impl CodecCapability {
     /// implementation.
     ///
     /// [2]: https://w3.org/TR/webrtc#dom-rtcrtpcodeccapability-mimetype
+    #[allow(clippy::unwrap_in_result)]
     pub fn mime_type(&self) -> Result<String, Error> {
         let mime_type =
             unsafe { codec_capability::mime_type(self.0.get()) }.unwrap();

--- a/src/platform/dart/codec_capability.rs
+++ b/src/platform/dart/codec_capability.rs
@@ -23,19 +23,24 @@ mod codec_capability {
 
     use dart_sys::Dart_Handle;
 
+    use crate::platform::Error;
+
     extern "C" {
         /// Returns [RTCRtpSender]'s available [RTCRtpCodecCapability][1]s.
         ///
         /// [RTCRtpSender]: https://w3.org/TR/webrtc#dom-rtcrtpsender
         /// [1]: https://w3.org/TR/webrtc#dom-rtcrtpcodeccapability
-        pub fn get_sender_codec_capabilities(kind: i64) -> Dart_Handle;
+        pub fn get_sender_codec_capabilities(
+            kind: i64,
+        ) -> Result<Dart_Handle, Error>;
 
         /// Returns [mimeType][2] of the provided [RTCRtpCodecCapability][1].
         ///
         /// [1]: https://w3.org/TR/webrtc#dom-rtcrtpcodeccapability
         /// [2]: https://w3.org/TR/webrtc#dom-rtcrtpcodeccapability-mimetype
-        pub fn mime_type(codec_capability: Dart_Handle)
-            -> ptr::NonNull<c_char>;
+        pub fn mime_type(
+            codec_capability: Dart_Handle,
+        ) -> Result<ptr::NonNull<c_char>, Error>;
     }
 }
 
@@ -65,7 +70,8 @@ impl CodecCapability {
     ) -> Result<Vec<Self>, Error> {
         let fut = unsafe {
             codec_capability::get_sender_codec_capabilities(kind as i64)
-        };
+        }
+        .unwrap();
 
         #[allow(clippy::map_err_ignore)]
         let res: DartHandle = unsafe { FutureFromDart::execute(fut) }
@@ -87,7 +93,8 @@ impl CodecCapability {
     ///
     /// [2]: https://w3.org/TR/webrtc#dom-rtcrtpcodeccapability-mimetype
     pub fn mime_type(&self) -> Result<String, Error> {
-        let mime_type = unsafe { codec_capability::mime_type(self.0.get()) };
+        let mime_type =
+            unsafe { codec_capability::mime_type(self.0.get()) }.unwrap();
         Ok(unsafe { dart_string_into_rust(mime_type) })
     }
 

--- a/src/platform/dart/constraints.rs
+++ b/src/platform/dart/constraints.rs
@@ -274,7 +274,7 @@ impl DisplayMediaStreamConstraints {
     }
 }
 
-#[allow(clippy::fallible_impl_from)]
+#[allow(clippy::fallible_impl_from)] // intentional
 impl From<AudioTrackConstraints> for MediaTrackConstraints {
     fn from(from: AudioTrackConstraints) -> Self {
         let optional = {
@@ -337,7 +337,7 @@ impl From<AudioTrackConstraints> for MediaTrackConstraints {
     }
 }
 
-#[allow(clippy::fallible_impl_from)]
+#[allow(clippy::fallible_impl_from)] // intentional
 impl From<DeviceVideoTrackConstraints> for MediaTrackConstraints {
     fn from(from: DeviceVideoTrackConstraints) -> Self {
         let optional = {
@@ -409,7 +409,7 @@ impl From<DeviceVideoTrackConstraints> for MediaTrackConstraints {
     }
 }
 
-#[allow(clippy::fallible_impl_from)]
+#[allow(clippy::fallible_impl_from)] // intentional
 impl From<DisplayVideoTrackConstraints> for MediaTrackConstraints {
     fn from(from: DisplayVideoTrackConstraints) -> Self {
         let optional = {

--- a/src/platform/dart/constraints.rs
+++ b/src/platform/dart/constraints.rs
@@ -275,6 +275,7 @@ impl DisplayMediaStreamConstraints {
     }
 }
 
+#[allow(clippy::fallible_impl_from)]
 impl From<AudioTrackConstraints> for MediaTrackConstraints {
     fn from(from: AudioTrackConstraints) -> Self {
         let optional = {
@@ -337,6 +338,7 @@ impl From<AudioTrackConstraints> for MediaTrackConstraints {
     }
 }
 
+#[allow(clippy::fallible_impl_from)]
 impl From<DeviceVideoTrackConstraints> for MediaTrackConstraints {
     fn from(from: DeviceVideoTrackConstraints) -> Self {
         let optional = {
@@ -408,6 +410,7 @@ impl From<DeviceVideoTrackConstraints> for MediaTrackConstraints {
     }
 }
 
+#[allow(clippy::fallible_impl_from)]
 impl From<DisplayVideoTrackConstraints> for MediaTrackConstraints {
     fn from(from: DisplayVideoTrackConstraints) -> Self {
         let optional = {

--- a/src/platform/dart/constraints.rs
+++ b/src/platform/dart/constraints.rs
@@ -170,7 +170,6 @@ impl MediaStreamConstraints {
     pub fn new() -> Self {
         let constraints =
             unsafe { constraints::init_device_constraints() }.unwrap();
-
         unsafe { Self(DartHandle::new(constraints)) }
     }
 

--- a/src/platform/dart/constraints.rs
+++ b/src/platform/dart/constraints.rs
@@ -22,28 +22,28 @@ use crate::{
 mod constraints {
     use dart_sys::Dart_Handle;
 
-    use crate::api::DartValue;
+    use crate::{api::DartValue, platform::Error};
 
     extern "C" {
         /// Initializes new empty [MediaStreamConstraints][0].
         ///
         /// [0]: https://w3.org/TR/mediacapture-streams#mediastreamconstraints
-        pub fn init_device_constraints() -> Dart_Handle;
+        pub fn init_device_constraints() -> Result<Dart_Handle, Error>;
 
         /// Initializes new empty [MediaStreamConstraints][0] for display.
         ///
         /// [0]: https://w3.org/TR/mediacapture-streams#mediastreamconstraints
-        pub fn init_display_constraints() -> Dart_Handle;
+        pub fn init_display_constraints() -> Result<Dart_Handle, Error>;
 
         /// Initializes a new empty [MediaStreamConstraints.video][0].
         ///
         /// [0]: https://tinyurl.com/3yvnbb9e
-        pub fn new_video_constraints() -> Dart_Handle;
+        pub fn new_video_constraints() -> Result<Dart_Handle, Error>;
 
         /// Initializes a new empty [MediaStreamConstraints.audio][0].
         ///
         /// [0]: https://tinyurl.com/5bmrr4w5
-        pub fn new_audio_constraints() -> Dart_Handle;
+        pub fn new_audio_constraints() -> Result<Dart_Handle, Error>;
 
         /// Specifies the provided setting of a
         /// [MediaStreamConstraints.video][0] (for example `facingMode`).
@@ -53,7 +53,7 @@ mod constraints {
             constraints: Dart_Handle,
             kind: i64,
             value: DartValue,
-        );
+        ) -> Result<(), Error>;
 
         /// Specifies the provided setting of a
         /// [MediaStreamConstraints.audio][0] (for example `deviceId`).
@@ -63,7 +63,7 @@ mod constraints {
             constraints: Dart_Handle,
             kind: i64,
             value: DartValue,
-        );
+        ) -> Result<(), Error>;
 
         /// Specifies the provided nature and settings of a `video`
         /// [MediaStreamTrack][1] to the given [MediaStreamConstraints][0].
@@ -74,7 +74,7 @@ mod constraints {
             constraints: Dart_Handle,
             ty: i64,
             video: Dart_Handle,
-        );
+        ) -> Result<(), Error>;
 
         /// Specifies the provided nature and settings of a display `video`
         /// [MediaStreamTrack][1] to the given [MediaStreamConstraints][0].
@@ -85,7 +85,7 @@ mod constraints {
             constraints: Dart_Handle,
             ty: i64,
             video: Dart_Handle,
-        );
+        ) -> Result<(), Error>;
 
         /// Specifies the provided nature and settings of an `audio`
         /// [MediaStreamTrack][1] to the given [MediaStreamConstraints][0].
@@ -96,7 +96,7 @@ mod constraints {
             constraints: Dart_Handle,
             ty: i64,
             audio: Dart_Handle,
-        );
+        ) -> Result<(), Error>;
     }
 }
 
@@ -168,7 +168,9 @@ impl MediaStreamConstraints {
     /// Creates new empty [`MediaStreamConstraints`].
     #[must_use]
     pub fn new() -> Self {
-        let constraints = unsafe { constraints::init_device_constraints() };
+        let constraints =
+            unsafe { constraints::init_device_constraints() }.unwrap();
+
         unsafe { Self(DartHandle::new(constraints)) }
     }
 
@@ -183,15 +185,17 @@ impl MediaStreamConstraints {
                 self.0.get(),
                 ConstraintType::Mandatory as i64,
                 audio.mandatory.get(),
-            );
+            )
         }
+        .unwrap();
         unsafe {
             constraints::set_audio_constraint(
                 self.0.get(),
                 ConstraintType::Optional as i64,
                 audio.optional.get(),
-            );
+            )
         }
+        .unwrap();
     }
 
     /// Specifies the provided nature and settings of a `video`
@@ -205,15 +209,17 @@ impl MediaStreamConstraints {
                 self.0.get(),
                 ConstraintType::Mandatory as i64,
                 video.mandatory.get(),
-            );
+            )
         }
+        .unwrap();
         unsafe {
             constraints::set_video_constraint(
                 self.0.get(),
                 ConstraintType::Optional as i64,
                 video.optional.get(),
-            );
+            )
         }
+        .unwrap();
     }
 }
 
@@ -239,7 +245,8 @@ impl DisplayMediaStreamConstraints {
     /// Creates new empty [`DisplayMediaStreamConstraints`] .
     #[must_use]
     pub fn new() -> Self {
-        let constraints = unsafe { constraints::init_display_constraints() };
+        let constraints =
+            unsafe { constraints::init_display_constraints() }.unwrap();
         unsafe { Self(DartHandle::new(constraints)) }
     }
 
@@ -254,26 +261,30 @@ impl DisplayMediaStreamConstraints {
                 self.0.get(),
                 ConstraintType::Mandatory as i64,
                 video.mandatory.get(),
-            );
+            )
         }
+        .unwrap();
         unsafe {
             constraints::set_display_video_constraint(
                 self.0.get(),
                 ConstraintType::Optional as i64,
                 video.optional.get(),
-            );
+            )
         }
+        .unwrap();
     }
 }
 
 impl From<AudioTrackConstraints> for MediaTrackConstraints {
     fn from(from: AudioTrackConstraints) -> Self {
         let optional = {
-            let audio = unsafe { constraints::new_audio_constraints() };
+            let audio =
+                unsafe { constraints::new_audio_constraints() }.unwrap();
             unsafe { DartHandle::new(audio) }
         };
         let mandatory = {
-            let audio = unsafe { constraints::new_audio_constraints() };
+            let audio =
+                unsafe { constraints::new_audio_constraints() }.unwrap();
             unsafe { DartHandle::new(audio) }
         };
 
@@ -284,15 +295,17 @@ impl From<AudioTrackConstraints> for MediaTrackConstraints {
                         mandatory.get(),
                         AudioConstraintKind::AutoGainControl as i64,
                         DartValue::from(auto_gain_control),
-                    );
-                },
+                    )
+                }
+                .unwrap(),
                 ConstrainBoolean::Ideal(auto_gain_control) => unsafe {
                     constraints::set_audio_constraint_value(
                         optional.get(),
                         AudioConstraintKind::AutoGainControl as i64,
                         DartValue::from(auto_gain_control),
-                    );
-                },
+                    )
+                }
+                .unwrap(),
             }
         }
 
@@ -303,15 +316,17 @@ impl From<AudioTrackConstraints> for MediaTrackConstraints {
                         mandatory.get(),
                         AudioConstraintKind::DeviceId as i64,
                         DartValue::from(device_id),
-                    );
-                },
+                    )
+                }
+                .unwrap(),
                 ConstrainString::Ideal(device_id) => unsafe {
                     constraints::set_audio_constraint_value(
                         optional.get(),
                         AudioConstraintKind::DeviceId as i64,
                         DartValue::from(device_id),
-                    );
-                },
+                    )
+                }
+                .unwrap(),
             }
         }
 
@@ -325,11 +340,13 @@ impl From<AudioTrackConstraints> for MediaTrackConstraints {
 impl From<DeviceVideoTrackConstraints> for MediaTrackConstraints {
     fn from(from: DeviceVideoTrackConstraints) -> Self {
         let optional = {
-            let video = unsafe { constraints::new_video_constraints() };
+            let video =
+                unsafe { constraints::new_video_constraints() }.unwrap();
             unsafe { DartHandle::new(video) }
         };
         let mandatory = {
-            let video = unsafe { constraints::new_video_constraints() };
+            let video =
+                unsafe { constraints::new_video_constraints() }.unwrap();
             unsafe { DartHandle::new(video) }
         };
 
@@ -350,15 +367,17 @@ impl From<DeviceVideoTrackConstraints> for MediaTrackConstraints {
                         mandatory.get(),
                         VideoConstraintKind::FacingMode as i64,
                         DartValue::from(facing_mode as i64),
-                    );
-                },
+                    )
+                }
+                .unwrap(),
                 ConstrainString::Ideal(facing_mode) => unsafe {
                     constraints::set_video_constraint_value(
                         optional.get(),
                         VideoConstraintKind::FacingMode as i64,
                         DartValue::from(facing_mode as i64),
-                    );
-                },
+                    )
+                }
+                .unwrap(),
             }
         }
         if let Some(width) = from.width {
@@ -392,11 +411,13 @@ impl From<DeviceVideoTrackConstraints> for MediaTrackConstraints {
 impl From<DisplayVideoTrackConstraints> for MediaTrackConstraints {
     fn from(from: DisplayVideoTrackConstraints) -> Self {
         let optional = {
-            let video = unsafe { constraints::new_video_constraints() };
+            let video =
+                unsafe { constraints::new_video_constraints() }.unwrap();
             unsafe { DartHandle::new(video) }
         };
         let mandatory = {
-            let video = unsafe { constraints::new_video_constraints() };
+            let video =
+                unsafe { constraints::new_video_constraints() }.unwrap();
             unsafe { DartHandle::new(video) }
         };
 
@@ -464,15 +485,17 @@ unsafe fn set_constrain_string<T>(
                 mandatory.get(),
                 kind as i64,
                 DartValue::from(val),
-            );
-        },
+            )
+        }
+        .unwrap(),
         ConstrainString::Ideal(val) => unsafe {
             constraints::set_video_constraint_value(
                 optional.get(),
                 kind as i64,
                 DartValue::from(val),
-            );
-        },
+            )
+        }
+        .unwrap(),
     }
 }
 
@@ -490,21 +513,24 @@ unsafe fn set_video_constrain_u32(
                 optional.get(),
                 kind as i64,
                 DartValue::from(val),
-            );
-        },
+            )
+        }
+        .unwrap(),
         ConstrainU32::Exact(val) => unsafe {
             constraints::set_video_constraint_value(
                 mandatory.get(),
                 kind as i64,
                 DartValue::from(val),
-            );
-        },
+            )
+        }
+        .unwrap(),
         ConstrainU32::Range(min, max) => unsafe {
             constraints::set_video_constraint_value(
                 mandatory.get(),
                 kind as i64,
                 DartValue::from(min),
-            );
-        },
+            )
+        }
+        .unwrap(),
     }
 }

--- a/src/platform/dart/ice_candidate.rs
+++ b/src/platform/dart/ice_candidate.rs
@@ -114,7 +114,6 @@ impl IceCandidateError {
     pub fn address(&self) -> String {
         let address =
             unsafe { ice_candidate_error::address(self.0.get()) }.unwrap();
-
         unsafe { dart_string_into_rust(address) }
     }
 
@@ -135,7 +134,6 @@ impl IceCandidateError {
     #[must_use]
     pub fn url(&self) -> String {
         let url = unsafe { ice_candidate_error::url(self.0.get()) }.unwrap();
-
         unsafe { dart_string_into_rust(url) }
     }
 
@@ -165,7 +163,6 @@ impl IceCandidateError {
     pub fn error_text(&self) -> String {
         let error_text =
             unsafe { ice_candidate_error::error_text(self.0.get()) }.unwrap();
-
         unsafe { dart_string_into_rust(error_text) }
     }
 }

--- a/src/platform/dart/ice_candidate.rs
+++ b/src/platform/dart/ice_candidate.rs
@@ -224,6 +224,7 @@ impl IceCandidate {
 
     /// Returns SDP MID of this [`IceCandidate`].
     #[must_use]
+    #[allow(clippy::unwrap_in_result)]
     pub fn sdp_mid(&self) -> Option<String> {
         let mid = unsafe { ice_candidate::sdp_mid(self.0.get()) }.unwrap();
         Some(unsafe { dart_string_into_rust(mid) })

--- a/src/platform/dart/ice_candidate.rs
+++ b/src/platform/dart/ice_candidate.rs
@@ -14,7 +14,7 @@ mod ice_candidate {
 
     use dart_sys::Dart_Handle;
 
-    use crate::api::DartValueArg;
+    use crate::{api::DartValueArg, platform::Error};
 
     extern "C" {
         /// Creates a new [`IceCandidate`] with the provided parameters.
@@ -22,16 +22,22 @@ mod ice_candidate {
             candidate: DartValueArg<String>,
             sdp_mid: DartValueArg<Option<String>>,
             sdp_m_line_index: DartValueArg<Option<u16>>,
-        ) -> Dart_Handle;
+        ) -> Result<Dart_Handle, Error>;
 
         /// Returns candidate of the provided [`IceCandidate`].
-        pub fn candidate(ice_candidate: Dart_Handle) -> ptr::NonNull<c_char>;
+        pub fn candidate(
+            ice_candidate: Dart_Handle,
+        ) -> Result<ptr::NonNull<c_char>, Error>;
 
         /// Returns SDP line index of the provided [`IceCandidate`].
-        pub fn sdp_m_line_index(ice_candidate: Dart_Handle) -> u64;
+        pub fn sdp_m_line_index(
+            ice_candidate: Dart_Handle,
+        ) -> Result<u64, Error>;
 
         /// Returns SDP MID of the provided [`IceCandidate`].
-        pub fn sdp_mid(ice_candidate: Dart_Handle) -> ptr::NonNull<c_char>;
+        pub fn sdp_mid(
+            ice_candidate: Dart_Handle,
+        ) -> Result<ptr::NonNull<c_char>, Error>;
     }
 }
 
@@ -41,26 +47,30 @@ mod ice_candidate_error {
 
     use dart_sys::Dart_Handle;
 
+    use crate::platform::Error;
+
     extern "C" {
         /// Returns the local IP address used to communicate with a
         /// [STUN]/[TURN] server.
         ///
         /// [STUN]: https://webrtcglossary.com/stun
         /// [TURN]: https://webrtcglossary.com/turn
-        pub fn address(error: Dart_Handle) -> ptr::NonNull<c_char>;
+        pub fn address(
+            error: Dart_Handle,
+        ) -> Result<ptr::NonNull<c_char>, Error>;
 
         /// Returns the port used to communicate with a [STUN]/[TURN] server.
         ///
         /// [STUN]: https://webrtcglossary.com/stun
         /// [TURN]: https://webrtcglossary.com/turn
-        pub fn port(error: Dart_Handle) -> u32;
+        pub fn port(error: Dart_Handle) -> Result<u32, Error>;
 
         /// Returns the URL identifying the [STUN]/[TURN] server for which the
         /// failure occurred.
         ///
         /// [STUN]: https://webrtcglossary.com/stun
         /// [TURN]: https://webrtcglossary.com/turn
-        pub fn url(error: Dart_Handle) -> ptr::NonNull<c_char>;
+        pub fn url(error: Dart_Handle) -> Result<ptr::NonNull<c_char>, Error>;
 
         /// Returns the Numeric [STUN] error code returned by the [STUN]/[TURN]
         /// server.
@@ -72,7 +82,7 @@ mod ice_candidate_error {
         ///
         /// [STUN]: https://webrtcglossary.com/stun
         /// [TURN]: https://webrtcglossary.com/turn
-        pub fn error_code(error: Dart_Handle) -> i32;
+        pub fn error_code(error: Dart_Handle) -> Result<i32, Error>;
 
         /// [STUN] reason text returned by the [STUN]/[TURN] server.
         ///
@@ -81,7 +91,9 @@ mod ice_candidate_error {
         ///
         /// [STUN]: https://webrtcglossary.com/stun
         /// [TURN]: https://webrtcglossary.com/turn
-        pub fn error_text(error: Dart_Handle) -> ptr::NonNull<c_char>;
+        pub fn error_text(
+            error: Dart_Handle,
+        ) -> Result<ptr::NonNull<c_char>, Error>;
     }
 }
 
@@ -100,7 +112,9 @@ impl IceCandidateError {
     /// [TURN]: https://webrtcglossary.com/turn
     #[must_use]
     pub fn address(&self) -> String {
-        let address = unsafe { ice_candidate_error::address(self.0.get()) };
+        let address =
+            unsafe { ice_candidate_error::address(self.0.get()) }.unwrap();
+
         unsafe { dart_string_into_rust(address) }
     }
 
@@ -110,7 +124,7 @@ impl IceCandidateError {
     /// [TURN]: https://webrtcglossary.com/turn
     #[must_use]
     pub fn port(&self) -> u32 {
-        unsafe { ice_candidate_error::port(self.0.get()) }
+        unsafe { ice_candidate_error::port(self.0.get()) }.unwrap()
     }
 
     /// Returns the URL identifying the [STUN]/[TURN] server for which the
@@ -120,7 +134,8 @@ impl IceCandidateError {
     /// [TURN]: https://webrtcglossary.com/turn
     #[must_use]
     pub fn url(&self) -> String {
-        let url = unsafe { ice_candidate_error::url(self.0.get()) };
+        let url = unsafe { ice_candidate_error::url(self.0.get()) }.unwrap();
+
         unsafe { dart_string_into_rust(url) }
     }
 
@@ -136,7 +151,7 @@ impl IceCandidateError {
     /// [TURN]: https://webrtcglossary.com/turn
     #[must_use]
     pub fn error_code(&self) -> i32 {
-        unsafe { ice_candidate_error::error_code(self.0.get()) }
+        unsafe { ice_candidate_error::error_code(self.0.get()) }.unwrap()
     }
 
     /// [STUN] reason text returned by the [STUN]/[TURN] server.
@@ -149,7 +164,8 @@ impl IceCandidateError {
     #[must_use]
     pub fn error_text(&self) -> String {
         let error_text =
-            unsafe { ice_candidate_error::error_text(self.0.get()) };
+            unsafe { ice_candidate_error::error_text(self.0.get()) }.unwrap();
+
         unsafe { dart_string_into_rust(error_text) }
     }
 }
@@ -175,7 +191,8 @@ impl IceCandidate {
                 sdp_mid.clone().into(),
                 sdp_m_line_index.map(i64::from).into(),
             )
-        };
+        }
+        .unwrap();
         Self(unsafe { DartHandle::new(handle) })
     }
 
@@ -188,7 +205,8 @@ impl IceCandidate {
     /// Returns candidate of this [`IceCandidate`].
     #[must_use]
     pub fn candidate(&self) -> String {
-        let candidate = unsafe { ice_candidate::candidate(self.0.get()) };
+        let candidate =
+            unsafe { ice_candidate::candidate(self.0.get()) }.unwrap();
         unsafe { dart_string_into_rust(candidate) }
     }
 
@@ -198,6 +216,7 @@ impl IceCandidate {
     pub fn sdp_m_line_index(&self) -> Option<u16> {
         Some(unsafe {
             ice_candidate::sdp_m_line_index(self.0.get())
+                .unwrap()
                 .try_into()
                 .unwrap()
         })
@@ -206,7 +225,7 @@ impl IceCandidate {
     /// Returns SDP MID of this [`IceCandidate`].
     #[must_use]
     pub fn sdp_mid(&self) -> Option<String> {
-        let mid = unsafe { ice_candidate::sdp_mid(self.0.get()) };
+        let mid = unsafe { ice_candidate::sdp_mid(self.0.get()) }.unwrap();
         Some(unsafe { dart_string_into_rust(mid) })
     }
 }

--- a/src/platform/dart/ice_candidate.rs
+++ b/src/platform/dart/ice_candidate.rs
@@ -221,7 +221,7 @@ impl IceCandidate {
 
     /// Returns SDP MID of this [`IceCandidate`].
     #[must_use]
-    #[allow(clippy::unwrap_in_result)]
+    #[allow(clippy::unwrap_in_result)] // intentional
     pub fn sdp_mid(&self) -> Option<String> {
         let mid = unsafe { ice_candidate::sdp_mid(self.0.get()) }.unwrap();
         Some(unsafe { dart_string_into_rust(mid) })

--- a/src/platform/dart/ice_server.rs
+++ b/src/platform/dart/ice_server.rs
@@ -14,12 +14,12 @@ mod ice_servers {
 
     use dart_sys::Dart_Handle;
 
-    use crate::api::DartValueArg;
+    use crate::{api::DartValueArg, platform::Error};
 
     extern "C" {
         /// Returns a [`Dart_Handle`] to the newly created empty `List` with
         /// `IceServer`s.
-        pub fn init() -> Dart_Handle;
+        pub fn init() -> Result<Dart_Handle, Error>;
 
         /// Adds an `IceServer` to the provided `List`.
         pub fn add(
@@ -27,7 +27,7 @@ mod ice_servers {
             url: ptr::NonNull<c_char>,
             username: DartValueArg<String>,
             credentials: DartValueArg<String>,
-        );
+        ) -> Result<(), Error>;
     }
 }
 
@@ -50,7 +50,7 @@ where
     I: IntoIterator<Item = IceServer>,
 {
     fn from(servers: I) -> Self {
-        let ice_servers = unsafe { ice_servers::init() };
+        let ice_servers = unsafe { ice_servers::init() }.unwrap();
         let ice_servers = unsafe { DartHandle::new(ice_servers) };
         for srv in servers {
             for url in srv.urls {
@@ -60,8 +60,9 @@ where
                         string_into_c_str(url),
                         srv.username.clone().into(),
                         srv.credential.clone().into(),
-                    );
+                    )
                 }
+                .unwrap()
             }
         }
         Self(ice_servers)

--- a/src/platform/dart/ice_server.rs
+++ b/src/platform/dart/ice_server.rs
@@ -45,7 +45,7 @@ impl RtcIceServers {
     }
 }
 
-#[allow(clippy::fallible_impl_from)]
+#[allow(clippy::fallible_impl_from)] // intentional
 impl<I> From<I> for RtcIceServers
 where
     I: IntoIterator<Item = IceServer>,

--- a/src/platform/dart/ice_server.rs
+++ b/src/platform/dart/ice_server.rs
@@ -45,6 +45,7 @@ impl RtcIceServers {
     }
 }
 
+#[allow(clippy::fallible_impl_from)]
 impl<I> From<I> for RtcIceServers
 where
     I: IntoIterator<Item = IceServer>,
@@ -62,7 +63,7 @@ where
                         srv.credential.clone().into(),
                     )
                 }
-                .unwrap()
+                .unwrap();
             }
         }
         Self(ice_servers)

--- a/src/platform/dart/media_device_info.rs
+++ b/src/platform/dart/media_device_info.rs
@@ -112,9 +112,9 @@ impl MediaDeviceInfo {
 impl TryFrom<DartHandle> for MediaDeviceInfo {
     type Error = NotInput;
 
-    #[allow(clippy::unwrap_in_result)]
+    #[allow(clippy::unwrap_in_result)] // intentional
     fn try_from(value: DartHandle) -> Result<Self, Self::Error> {
-        #[allow(clippy::map_err_ignore)]
+        #[allow(clippy::map_err_ignore)] // intentional
         let kind = unsafe { media_device_info::kind(value.get()) }
             .unwrap()
             .try_into()

--- a/src/platform/dart/media_device_info.rs
+++ b/src/platform/dart/media_device_info.rs
@@ -112,6 +112,7 @@ impl MediaDeviceInfo {
 impl TryFrom<DartHandle> for MediaDeviceInfo {
     type Error = NotInput;
 
+    #[allow(clippy::unwrap_in_result)]
     fn try_from(value: DartHandle) -> Result<Self, Self::Error> {
         #[allow(clippy::map_err_ignore)]
         let kind = unsafe { media_device_info::kind(value.get()) }

--- a/src/platform/dart/media_devices.rs
+++ b/src/platform/dart/media_devices.rs
@@ -84,6 +84,7 @@ mod media_devices {
     }
 }
 
+#[allow(clippy::fallible_impl_from)]
 impl From<Error> for GetUserMediaError {
     fn from(err: Error) -> Self {
         let kind = unsafe {

--- a/src/platform/dart/media_devices.rs
+++ b/src/platform/dart/media_devices.rs
@@ -84,7 +84,7 @@ mod media_devices {
     }
 }
 
-#[allow(clippy::fallible_impl_from)]
+#[allow(clippy::fallible_impl_from)] // intentional
 impl From<Error> for GetUserMediaError {
     fn from(err: Error) -> Self {
         let kind = unsafe {

--- a/src/platform/dart/media_display_info.rs
+++ b/src/platform/dart/media_display_info.rs
@@ -13,16 +13,18 @@ mod media_display_info {
 
     use dart_sys::Dart_Handle;
 
-    use crate::api::DartValueArg;
+    use crate::{api::DartValueArg, platform::Error};
 
     extern "C" {
         /// Returns a unique identifier of the provided display.
-        pub fn device_id(info: Dart_Handle) -> ptr::NonNull<c_char>;
+        pub fn device_id(
+            info: Dart_Handle,
+        ) -> Result<ptr::NonNull<c_char>, Error>;
 
         /// Returns a title describing the represented display.
         pub fn title(
             info: Dart_Handle,
-        ) -> ptr::NonNull<DartValueArg<Option<String>>>;
+        ) -> Result<ptr::NonNull<DartValueArg<Option<String>>>, Error>;
     }
 }
 
@@ -35,7 +37,9 @@ impl MediaDisplayInfo {
     /// [`MediaDisplayInfo`].
     #[must_use]
     pub fn device_id(&self) -> String {
-        let device_id = unsafe { media_display_info::device_id(self.0.get()) };
+        let device_id =
+            unsafe { media_display_info::device_id(self.0.get()) }.unwrap();
+
         unsafe { dart_string_into_rust(device_id) }
     }
 
@@ -43,7 +47,8 @@ impl MediaDisplayInfo {
     #[allow(clippy::unwrap_in_result)]
     #[must_use]
     pub fn title(&self) -> Option<String> {
-        let title = unsafe { media_display_info::title(self.0.get()) };
+        let title = unsafe { media_display_info::title(self.0.get()) }.unwrap();
+
         Option::try_from(unsafe { title.unbox() }).unwrap()
     }
 }

--- a/src/platform/dart/media_display_info.rs
+++ b/src/platform/dart/media_display_info.rs
@@ -39,7 +39,6 @@ impl MediaDisplayInfo {
     pub fn device_id(&self) -> String {
         let device_id =
             unsafe { media_display_info::device_id(self.0.get()) }.unwrap();
-
         unsafe { dart_string_into_rust(device_id) }
     }
 
@@ -48,7 +47,6 @@ impl MediaDisplayInfo {
     #[must_use]
     pub fn title(&self) -> Option<String> {
         let title = unsafe { media_display_info::title(self.0.get()) }.unwrap();
-
         Option::try_from(unsafe { title.unbox() }).unwrap()
     }
 }

--- a/src/platform/dart/media_track.rs
+++ b/src/platform/dart/media_track.rs
@@ -191,7 +191,7 @@ impl MediaStreamTrack {
     /// [1]: https://w3.org/TR/mediacapture-streams#dfn-deviceid
     #[inline]
     #[must_use]
-    #[allow(clippy::unwrap_in_result)]
+    #[allow(clippy::unwrap_in_result)] // intentional
     pub fn device_id(&self) -> Option<String> {
         let device_id =
             unsafe { media_stream_track::device_id(self.inner.get()) }.unwrap();

--- a/src/platform/dart/media_track.rs
+++ b/src/platform/dart/media_track.rs
@@ -183,7 +183,6 @@ impl MediaStreamTrack {
     #[must_use]
     pub fn id(&self) -> String {
         let id = unsafe { media_stream_track::id(self.inner.get()) }.unwrap();
-
         unsafe { dart_string_into_rust(id) }
     }
 
@@ -196,7 +195,6 @@ impl MediaStreamTrack {
     pub fn device_id(&self) -> Option<String> {
         let device_id =
             unsafe { media_stream_track::device_id(self.inner.get()) }.unwrap();
-
         Some(unsafe { dart_string_into_rust(device_id) })
     }
 
@@ -221,7 +219,6 @@ impl MediaStreamTrack {
         let facing_mode =
             unsafe { media_stream_track::facing_mode(self.inner.get()) }
                 .unwrap();
-
         Option::<i64>::try_from(unsafe { facing_mode.unbox() })
             .unwrap()
             .map(FacingMode::try_from)
@@ -237,7 +234,6 @@ impl MediaStreamTrack {
     pub fn height(&self) -> Option<u32> {
         let height =
             unsafe { media_stream_track::height(self.inner.get()) }.unwrap();
-
         Option::try_from(unsafe { height.unbox() }).unwrap()
     }
 
@@ -249,7 +245,6 @@ impl MediaStreamTrack {
     pub fn width(&self) -> Option<u32> {
         let width =
             unsafe { media_stream_track::width(self.inner.get()) }.unwrap();
-
         Option::try_from(unsafe { width.unbox() }).unwrap()
     }
 
@@ -295,7 +290,6 @@ impl MediaStreamTrack {
         let inner = self.inner.clone();
         async move {
             let fut = unsafe { media_stream_track::stop(inner.get()) }.unwrap();
-
             unsafe { FutureFromDart::execute::<()>(fut) }.await.unwrap();
         }
     }
@@ -386,7 +380,6 @@ impl Drop for MediaStreamTrack {
         platform::spawn(async move {
             let fut =
                 unsafe { media_stream_track::dispose(track.get()) }.unwrap();
-
             unsafe { FutureFromDart::execute::<()>(fut) }.await.unwrap();
         });
     }

--- a/src/platform/dart/media_track.rs
+++ b/src/platform/dart/media_track.rs
@@ -192,6 +192,7 @@ impl MediaStreamTrack {
     /// [1]: https://w3.org/TR/mediacapture-streams#dfn-deviceid
     #[inline]
     #[must_use]
+    #[allow(clippy::unwrap_in_result)]
     pub fn device_id(&self) -> Option<String> {
         let device_id =
             unsafe { media_stream_track::device_id(self.inner.get()) }.unwrap();

--- a/src/platform/dart/media_track.rs
+++ b/src/platform/dart/media_track.rs
@@ -27,26 +27,28 @@ mod media_stream_track {
 
     use dart_sys::Dart_Handle;
 
-    use crate::api::DartValueArg;
+    use crate::{api::DartValueArg, platform::Error};
 
     extern "C" {
         /// Returns [ID][1] of the provided [MediaStreamTrack][0].
         ///
         /// [0]: https://w3.org/TR/mediacapture-streams#mediastreamtrack
         /// [1]: https://w3.org/TR/mediacapture-streams#dom-mediastreamtrack-id
-        pub fn id(track: Dart_Handle) -> ptr::NonNull<c_char>;
+        pub fn id(track: Dart_Handle) -> Result<ptr::NonNull<c_char>, Error>;
 
         /// Returns [device ID][1] of the provided [MediaStreamTrack][0].
         ///
         /// [0]: https://w3.org/TR/mediacapture-streams#mediastreamtrack
         /// [1]: https://w3.org/TR/mediacapture-streams#dfn-deviceid
-        pub fn device_id(track: Dart_Handle) -> ptr::NonNull<c_char>;
+        pub fn device_id(
+            track: Dart_Handle,
+        ) -> Result<ptr::NonNull<c_char>, Error>;
 
         /// Returns [kind][1] of the provided [MediaStreamTrack][0].
         ///
         /// [0]: https://w3.org/TR/mediacapture-streams#mediastreamtrack
         /// [1]: https://tinyurl.com/w3-streams#dom-mediastreamtrack-kind
-        pub fn kind(track: Dart_Handle) -> i64;
+        pub fn kind(track: Dart_Handle) -> Result<i64, Error>;
 
         /// Returns [facing mode][1] of the provided [MediaStreamTrack][0].
         ///
@@ -54,7 +56,7 @@ mod media_stream_track {
         /// [1]: https://tinyurl.com/w3-streams#def-constraint-facingMode
         pub fn facing_mode(
             track: Dart_Handle,
-        ) -> ptr::NonNull<DartValueArg<Option<i64>>>;
+        ) -> Result<ptr::NonNull<DartValueArg<Option<i64>>>, Error>;
 
         /// Returns [height][1] of the provided [MediaStreamTrack][0].
         ///
@@ -62,7 +64,7 @@ mod media_stream_track {
         /// [1]: https://tinyurl.com/w3-streams#dom-mediatracksettings-height
         pub fn height(
             track: Dart_Handle,
-        ) -> ptr::NonNull<DartValueArg<Option<u32>>>;
+        ) -> Result<ptr::NonNull<DartValueArg<Option<u32>>>, Error>;
 
         /// Returns [width][1] of the provided [MediaStreamTrack][0].
         ///
@@ -70,55 +72,63 @@ mod media_stream_track {
         /// [1]: https://tinyurl.com/w3-streams#dom-mediatracksettings-width
         pub fn width(
             track: Dart_Handle,
-        ) -> ptr::NonNull<DartValueArg<Option<u32>>>;
+        ) -> Result<ptr::NonNull<DartValueArg<Option<u32>>>, Error>;
 
         /// Returns [enabled][1] field of the provided [MediaStreamTrack][0].
         ///
         /// [0]: https://w3.org/TR/mediacapture-streams#mediastreamtrack
         /// [1]: https://tinyurl.com/w3-streams#dom-mediastreamtrack-enabled
-        pub fn enabled(track: Dart_Handle) -> bool;
+        pub fn enabled(track: Dart_Handle) -> Result<bool, Error>;
 
         /// Sets [enabled][1] field of the provided [MediaStreamTrack][0].
         ///
         /// [0]: https://w3.org/TR/mediacapture-streams#mediastreamtrack
         /// [1]: https://tinyurl.com/w3-streams#dom-mediastreamtrack-enabled
-        pub fn set_enabled(track: Dart_Handle, is_enabled: bool);
+        pub fn set_enabled(
+            track: Dart_Handle,
+            is_enabled: bool,
+        ) -> Result<(), Error>;
 
         /// Returns [readiness state][1] of the provided [MediaStreamTrack][0].
         ///
         /// [0]: https://w3.org/TR/mediacapture-streams#mediastreamtrack
         /// [1]: https://tinyurl.com/w3-streams#dom-mediastreamtrack-readystate
-        pub fn ready_state(track: Dart_Handle) -> Dart_Handle;
+        pub fn ready_state(track: Dart_Handle) -> Result<Dart_Handle, Error>;
 
         /// [Stops][1] the provided [MediaStreamTrack][0].
         ///
         /// [0]: https://w3.org/TR/mediacapture-streams#mediastreamtrack
         /// [1]: https://tinyurl.com/w3-streams#dom-mediastreamtrack-stop
-        pub fn stop(track: Dart_Handle) -> Dart_Handle;
+        pub fn stop(track: Dart_Handle) -> Result<Dart_Handle, Error>;
 
         /// Sets [`onended`][1] event handler of the provided
         /// [MediaStreamTrack][0].
         ///
         /// [0]: https://w3.org/TR/mediacapture-streams#mediastreamtrack
         /// [1]: https://tinyurl.com/w3-streams#dom-mediastreamtrack-onended
-        pub fn on_ended(track: Dart_Handle, cb: Dart_Handle);
+        pub fn on_ended(
+            track: Dart_Handle,
+            cb: Dart_Handle,
+        ) -> Result<(), Error>;
 
         /// Creates a new instance of [MediaStreamTrack][0] depending on the
         /// same media source as the provided one has.
         ///
         /// [0]: https://w3.org/TR/mediacapture-streams#mediastreamtrack
-        pub fn clone(track: Dart_Handle) -> Dart_Handle;
+        pub fn clone(track: Dart_Handle) -> Result<Dart_Handle, Error>;
 
         /// Disposes the provided [MediaStreamTrack][0].
         ///
         /// [0]: https://w3.org/TR/mediacapture-streams#mediastreamtrack
-        pub fn dispose(track: Dart_Handle) -> Dart_Handle;
+        pub fn dispose(track: Dart_Handle) -> Result<Dart_Handle, Error>;
 
         /// Indicates whether an `OnAudioLevelChangedCallback` is supported for
         /// this [MediaStreamTrack][0].
         ///
         /// [0]: https://w3.org/TR/mediacapture-streams#mediastreamtrack
-        pub fn is_on_audio_level_available(track: Dart_Handle) -> bool;
+        pub fn is_on_audio_level_available(
+            track: Dart_Handle,
+        ) -> Result<bool, Error>;
 
         /// Sets the provided `OnAudioLevelChangedCallback` for this
         /// [MediaStreamTrack][0].
@@ -127,7 +137,10 @@ mod media_stream_track {
         /// changes.
         ///
         /// [0]: https://w3.org/TR/mediacapture-streams#mediastreamtrack
-        pub fn on_audio_level_changed(track: Dart_Handle, cb: Dart_Handle);
+        pub fn on_audio_level_changed(
+            track: Dart_Handle,
+            cb: Dart_Handle,
+        ) -> Result<(), Error>;
     }
 }
 
@@ -169,7 +182,8 @@ impl MediaStreamTrack {
     /// [1]: https://w3.org/TR/mediacapture-streams#dom-mediastreamtrack-id
     #[must_use]
     pub fn id(&self) -> String {
-        let id = unsafe { media_stream_track::id(self.inner.get()) };
+        let id = unsafe { media_stream_track::id(self.inner.get()) }.unwrap();
+
         unsafe { dart_string_into_rust(id) }
     }
 
@@ -180,7 +194,8 @@ impl MediaStreamTrack {
     #[must_use]
     pub fn device_id(&self) -> Option<String> {
         let device_id =
-            unsafe { media_stream_track::device_id(self.inner.get()) };
+            unsafe { media_stream_track::device_id(self.inner.get()) }.unwrap();
+
         Some(unsafe { dart_string_into_rust(device_id) })
     }
 
@@ -190,9 +205,9 @@ impl MediaStreamTrack {
     #[inline]
     #[must_use]
     pub fn kind(&self) -> MediaKind {
-        MediaKind::try_from(unsafe {
-            media_stream_track::kind(self.inner.get())
-        })
+        MediaKind::try_from(
+            unsafe { media_stream_track::kind(self.inner.get()) }.unwrap(),
+        )
         .unwrap()
     }
 
@@ -203,7 +218,9 @@ impl MediaStreamTrack {
     #[must_use]
     pub fn facing_mode(&self) -> Option<FacingMode> {
         let facing_mode =
-            unsafe { media_stream_track::facing_mode(self.inner.get()) };
+            unsafe { media_stream_track::facing_mode(self.inner.get()) }
+                .unwrap();
+
         Option::<i64>::try_from(unsafe { facing_mode.unbox() })
             .unwrap()
             .map(FacingMode::try_from)
@@ -217,7 +234,9 @@ impl MediaStreamTrack {
     #[allow(clippy::unwrap_in_result)]
     #[must_use]
     pub fn height(&self) -> Option<u32> {
-        let height = unsafe { media_stream_track::height(self.inner.get()) };
+        let height =
+            unsafe { media_stream_track::height(self.inner.get()) }.unwrap();
+
         Option::try_from(unsafe { height.unbox() }).unwrap()
     }
 
@@ -227,7 +246,9 @@ impl MediaStreamTrack {
     #[allow(clippy::unwrap_in_result)]
     #[must_use]
     pub fn width(&self) -> Option<u32> {
-        let width = unsafe { media_stream_track::width(self.inner.get()) };
+        let width =
+            unsafe { media_stream_track::width(self.inner.get()) }.unwrap();
+
         Option::try_from(unsafe { width.unbox() }).unwrap()
     }
 
@@ -237,16 +258,15 @@ impl MediaStreamTrack {
     #[inline]
     #[must_use]
     pub fn enabled(&self) -> bool {
-        unsafe { media_stream_track::enabled(self.inner.get()) }
+        unsafe { media_stream_track::enabled(self.inner.get()) }.unwrap()
     }
 
     /// Sets [enabled][1] field of this [`MediaStreamTrack`].
     ///
     /// [1]: https://w3.org/TR/mediacapture-streams#dom-mediastreamtrack-enabled
     pub fn set_enabled(&self, enabled: bool) {
-        unsafe {
-            media_stream_track::set_enabled(self.inner.get(), enabled);
-        }
+        unsafe { media_stream_track::set_enabled(self.inner.get(), enabled) }
+            .unwrap();
     }
 
     /// Returns [readiness state][1] of this [`MediaStreamTrack`].
@@ -254,7 +274,7 @@ impl MediaStreamTrack {
     /// [1]: https://tinyurl.com/w3-streams#dom-mediastreamtrack-readystate
     pub async fn ready_state(&self) -> MediaStreamTrackState {
         let handle = self.inner.get();
-        let state = unsafe { media_stream_track::ready_state(handle) };
+        let state = unsafe { media_stream_track::ready_state(handle) }.unwrap();
         let state = unsafe { FutureFromDart::execute::<i64>(state) }
             .await
             .unwrap();
@@ -273,7 +293,8 @@ impl MediaStreamTrack {
     pub fn stop(&self) -> impl Future<Output = ()> + 'static {
         let inner = self.inner.clone();
         async move {
-            let fut = unsafe { media_stream_track::stop(inner.get()) };
+            let fut = unsafe { media_stream_track::stop(inner.get()) }.unwrap();
+
             unsafe { FutureFromDart::execute::<()>(fut) }.await.unwrap();
         }
     }
@@ -304,7 +325,7 @@ impl MediaStreamTrack {
         let handle = self.inner.get();
         let source_kind = self.source_kind;
         async move {
-            let fut = unsafe { media_stream_track::clone(handle) };
+            let fut = unsafe { media_stream_track::clone(handle) }.unwrap();
             let new_track: DartHandle =
                 unsafe { FutureFromDart::execute(fut) }.await.unwrap();
             Self::new(new_track, source_kind)
@@ -321,8 +342,9 @@ impl MediaStreamTrack {
         if let Some(cb) = f {
             let cb = Callback::from_once(|(): ()| cb());
             unsafe {
-                media_stream_track::on_ended(self.inner.get(), cb.into_dart());
-            };
+                media_stream_track::on_ended(self.inner.get(), cb.into_dart())
+            }
+            .unwrap();
         }
     }
 
@@ -333,6 +355,7 @@ impl MediaStreamTrack {
         unsafe {
             media_stream_track::is_on_audio_level_available(self.inner.get())
         }
+        .unwrap()
     }
 
     /// Sets the provided `OnAudioLevelChangedCallback` for this
@@ -350,8 +373,9 @@ impl MediaStreamTrack {
             media_stream_track::on_audio_level_changed(
                 self.inner.get(),
                 cb.into_dart(),
-            );
-        };
+            )
+        }
+        .unwrap();
     }
 }
 
@@ -359,7 +383,9 @@ impl Drop for MediaStreamTrack {
     fn drop(&mut self) {
         let track = self.inner.clone();
         platform::spawn(async move {
-            let fut = unsafe { media_stream_track::dispose(track.get()) };
+            let fut =
+                unsafe { media_stream_track::dispose(track.get()) }.unwrap();
+
             unsafe { FutureFromDart::execute::<()>(fut) }.await.unwrap();
         });
     }

--- a/src/platform/dart/parameters.rs
+++ b/src/platform/dart/parameters.rs
@@ -17,13 +17,16 @@ use super::{
 mod parameters {
     use dart_sys::Dart_Handle;
 
+    use crate::platform::Error;
+
     extern "C" {
         /// Returns [RTCRtpEncodingParameters][1] from the provided
         /// [RTCRtpParameters].
         ///
         /// [RTCRtpParameters]: https://w3.org/TR/webrtc#dom-rtcrtpparameters
         /// [1]: https://w3.org/TR/webrtc#dom-rtcrtpencodingparameters
-        pub fn encodings(parameters: Dart_Handle) -> Dart_Handle;
+        pub fn encodings(parameters: Dart_Handle)
+            -> Result<Dart_Handle, Error>;
 
         /// Sets the provided [RTCRtpEncodingParameters][1] into the provided
         /// [RTCRtpParameters].
@@ -33,7 +36,7 @@ mod parameters {
         pub fn set_encoding(
             parameters: Dart_Handle,
             encoding: Dart_Handle,
-        ) -> Dart_Handle;
+        ) -> Result<Dart_Handle, Error>;
     }
 }
 
@@ -59,7 +62,7 @@ impl Parameters {
         let handle = self.0.get();
 
         Box::pin(async move {
-            let fut = unsafe { parameters::encodings(handle) };
+            let fut = unsafe { parameters::encodings(handle) }.unwrap();
             let encodings =
                 unsafe { FutureFromDart::execute::<DartHandle>(fut) }.await?;
 
@@ -83,7 +86,9 @@ impl Parameters {
         let handle = self.0.get();
         let enc_handle = encoding.handle();
         Box::pin(async move {
-            let fut = unsafe { parameters::set_encoding(handle, enc_handle) };
+            let fut = unsafe { parameters::set_encoding(handle, enc_handle) }
+                .unwrap();
+
             unsafe { FutureFromDart::execute::<()>(fut) }.await.unwrap();
         })
     }

--- a/src/platform/dart/parameters.rs
+++ b/src/platform/dart/parameters.rs
@@ -88,7 +88,6 @@ impl Parameters {
         Box::pin(async move {
             let fut = unsafe { parameters::set_encoding(handle, enc_handle) }
                 .unwrap();
-
             unsafe { FutureFromDart::execute::<()>(fut) }.await.unwrap();
         })
     }

--- a/src/platform/dart/peer_connection.rs
+++ b/src/platform/dart/peer_connection.rs
@@ -456,7 +456,6 @@ impl RtcPeerConnection {
     pub async fn create_answer(&self) -> RtcPeerConnectionResult<String> {
         let fut = unsafe { peer_connection::create_answer(self.handle.get()) }
             .unwrap();
-
         unsafe { FutureFromDart::execute(fut) }
             .await
             .map_err(RtcPeerConnectionError::CreateAnswerFailed)
@@ -474,7 +473,6 @@ impl RtcPeerConnection {
     pub async fn rollback(&self) -> RtcPeerConnectionResult<()> {
         let fut =
             unsafe { peer_connection::rollback(self.handle.get()) }.unwrap();
-
         unsafe { FutureFromDart::execute(fut) }
             .await
             .map_err(RtcPeerConnectionError::SetLocalDescriptionFailed)
@@ -495,7 +493,6 @@ impl RtcPeerConnection {
     pub async fn create_offer(&self) -> RtcPeerConnectionResult<String> {
         let fut = unsafe { peer_connection::create_offer(self.handle.get()) }
             .unwrap();
-
         unsafe { FutureFromDart::execute(fut) }
             .await
             .map_err(RtcPeerConnectionError::CreateOfferFailed)

--- a/src/platform/dart/peer_connection.rs
+++ b/src/platform/dart/peer_connection.rs
@@ -46,84 +46,96 @@ mod peer_connection {
 
     use dart_sys::Dart_Handle;
 
-    use crate::api::DartValueArg;
+    use crate::{api::DartValueArg, platform::Error};
 
     extern "C" {
         /// Returns [`IceConnectionState`] of the provided [`PeerConnection`].
-        pub fn ice_connection_state(peer: Dart_Handle) -> i32;
+        pub fn ice_connection_state(peer: Dart_Handle) -> Result<i32, Error>;
 
         /// Sets the provided callback to a [`connectionstatechange`][1] event
         /// of the provided [`PeerConnection`].
         ///
         /// [1]: https://w3.org/TR/webrtc#event-connectionstatechange
-        pub fn on_connection_state_change(peer: Dart_Handle, cb: Dart_Handle);
+        pub fn on_connection_state_change(
+            peer: Dart_Handle,
+            cb: Dart_Handle,
+        ) -> Result<(), Error>;
 
         /// Returns a [`ConnectionState`] of the provided [`PeerConnection`].
         pub fn connection_state(
             peer: Dart_Handle,
-        ) -> ptr::NonNull<DartValueArg<Option<i32>>>;
+        ) -> Result<ptr::NonNull<DartValueArg<Option<i32>>>, Error>;
 
         /// Requests an ICE candidate gathering redoing on both ends of the
         /// connection.
-        pub fn restart_ice(peer: Dart_Handle);
+        pub fn restart_ice(peer: Dart_Handle) -> Result<(), Error>;
 
         /// Rollbacks SDP offer of the provided [`PeerConnection`].
-        pub fn rollback(peer: Dart_Handle) -> Dart_Handle;
+        pub fn rollback(peer: Dart_Handle) -> Result<Dart_Handle, Error>;
 
         /// Returns JSON encoded [`Vec`] of [`RtcStats`] from the provided
         /// [`PeerConnection`].
-        pub fn get_stats(peer: Dart_Handle) -> Dart_Handle;
+        pub fn get_stats(peer: Dart_Handle) -> Result<Dart_Handle, Error>;
 
         /// Sets `onTrack` callback of the provided [`PeerConnection`].
-        pub fn on_track(peer: Dart_Handle, cb: Dart_Handle);
+        pub fn on_track(
+            peer: Dart_Handle,
+            cb: Dart_Handle,
+        ) -> Result<(), Error>;
 
         /// Sets `onIceCandidate` callback of the provided [`PeerConnection`].
-        pub fn on_ice_candidate(peer: Dart_Handle, cb: Dart_Handle);
+        pub fn on_ice_candidate(
+            peer: Dart_Handle,
+            cb: Dart_Handle,
+        ) -> Result<(), Error>;
 
         /// Sets `onIceCandidateError` callback of the provided
         /// [`PeerConnection`].
-        pub fn on_ice_candidate_error(peer: Dart_Handle, cb: Dart_Handle);
+        pub fn on_ice_candidate_error(
+            peer: Dart_Handle,
+            cb: Dart_Handle,
+        ) -> Result<(), Error>;
 
         /// Looks ups [`Transceiver`] in the provided [`PeerConnection`] by the
         /// provided [`String`].
         pub fn get_transceiver_by_mid(
             peer: Dart_Handle,
             mid: ptr::NonNull<c_char>,
-        ) -> Dart_Handle;
+        ) -> Result<Dart_Handle, Error>;
 
         /// Adds the provided [`IceCandidate`] to the provided
         /// [`PeerConnection`].
         pub fn add_ice_candidate(
             peer: Dart_Handle,
             candidate: Dart_Handle,
-        ) -> Dart_Handle;
+        ) -> Result<Dart_Handle, Error>;
 
         /// Sets a callback for an [`iceconnectionstatechange`][1] event of the
         /// provided [`PeerConnection`].
         pub fn on_ice_connection_state_change(
             peer: Dart_Handle,
             cb: Dart_Handle,
-        );
+        ) -> Result<(), Error>;
 
         /// Returns a [`Dart_Handle`] to a newly created [`PeerConnection`].
         pub fn new_peer(
             ice_servers: Dart_Handle,
             is_force_relayed: bool,
-        ) -> Dart_Handle;
+        ) -> Result<Dart_Handle, Error>;
 
         /// Creates a new [`Transceiver`] in the provided [`PeerConnection`].
         pub fn add_transceiver(
             peer: Dart_Handle,
             kind: i64,
             init: Dart_Handle,
-        ) -> Dart_Handle;
+        ) -> Result<Dart_Handle, Error>;
 
         /// Returns newly created SDP offer of the provided [`PeerConnection`].
-        pub fn create_offer(peer: Dart_Handle) -> Dart_Handle;
+        pub fn create_offer(peer: Dart_Handle) -> Result<Dart_Handle, Error>;
 
         /// Returns a newly created SDP answer of the provided
         /// [`PeerConnection`].
-        pub fn create_answer(peer: Dart_Handle) -> Dart_Handle;
+        pub fn create_answer(peer: Dart_Handle) -> Result<Dart_Handle, Error>;
 
         /// Sets the provided SDP offer as a local description of the provided
         /// [`PeerConnection`].
@@ -131,7 +143,7 @@ mod peer_connection {
             peer: Dart_Handle,
             ty: ptr::NonNull<c_char>,
             offer: ptr::NonNull<c_char>,
-        ) -> Dart_Handle;
+        ) -> Result<Dart_Handle, Error>;
 
         /// Sets the provided SDP offer as a remote description of the provided
         /// [`PeerConnection`].
@@ -139,10 +151,10 @@ mod peer_connection {
             peer: Dart_Handle,
             ty: ptr::NonNull<c_char>,
             offer: ptr::NonNull<c_char>,
-        ) -> Dart_Handle;
+        ) -> Result<Dart_Handle, Error>;
 
         /// Closes the provided [`PeerConnection`].
-        pub fn close(peer: Dart_Handle);
+        pub fn close(peer: Dart_Handle) -> Result<(), Error>;
     }
 }
 
@@ -174,7 +186,8 @@ impl RtcPeerConnection {
                 ice_servers.get_handle(),
                 is_force_relayed,
             )
-        };
+        }
+        .unwrap();
         Ok(Self {
             handle: unsafe { FutureFromDart::execute(fut) }
                 .await
@@ -186,7 +199,8 @@ impl RtcPeerConnection {
     /// Returns [`RtcStats`] of this [`RtcPeerConnection`].
     #[allow(clippy::missing_errors_doc, clippy::unused_async)]
     pub async fn get_stats(&self) -> RtcPeerConnectionResult<RtcStats> {
-        let fut = unsafe { peer_connection::get_stats(self.handle.get()) };
+        let fut =
+            unsafe { peer_connection::get_stats(self.handle.get()) }.unwrap();
         let stats_json: String = unsafe { FutureFromDart::execute(fut) }
             .await
             .map_err(RtcStatsError::Platform)
@@ -219,8 +233,9 @@ impl RtcPeerConnection {
                         },
                     )
                     .into_dart(),
-                );
-            };
+                )
+            }
+            .unwrap();
         }
     }
 
@@ -253,8 +268,9 @@ impl RtcPeerConnection {
                         }
                     })
                     .into_dart(),
-                );
+                )
             }
+            .unwrap();
         }
     }
 
@@ -282,8 +298,9 @@ impl RtcPeerConnection {
                         });
                     })
                     .into_dart(),
-                );
+                )
             }
+            .unwrap();
         }
     }
 
@@ -291,7 +308,8 @@ impl RtcPeerConnection {
     #[must_use]
     pub fn ice_connection_state(&self) -> IceConnectionState {
         let ice_connection_state =
-            unsafe { peer_connection::ice_connection_state(self.handle.get()) };
+            unsafe { peer_connection::ice_connection_state(self.handle.get()) }
+                .unwrap();
         ice_connection_from_int(ice_connection_state)
     }
 
@@ -302,7 +320,8 @@ impl RtcPeerConnection {
     #[must_use]
     pub fn connection_state(&self) -> Option<PeerConnectionState> {
         let conn_state =
-            unsafe { peer_connection::connection_state(self.handle.get()) };
+            unsafe { peer_connection::connection_state(self.handle.get()) }
+                .unwrap();
         let conn_state =
             Option::try_from(unsafe { *Box::from_raw(conn_state.as_ptr()) })
                 .unwrap()?;
@@ -324,8 +343,9 @@ impl RtcPeerConnection {
                         h(ice_connection_from_int(v));
                     })
                     .into_dart(),
-                );
+                )
             }
+            .unwrap();
         }
     }
 
@@ -344,8 +364,9 @@ impl RtcPeerConnection {
                         h(peer_connection_state_from_int(v));
                     })
                     .into_dart(),
-                );
+                )
             }
+            .unwrap();
         }
     }
 
@@ -372,7 +393,8 @@ impl RtcPeerConnection {
                 PlatformIceCandidate::new(candidate, sdp_m_line_index, sdp_mid)
                     .handle(),
             )
-        };
+        }
+        .unwrap();
         unsafe { FutureFromDart::execute::<()>(fut) }
             .await
             .map_err(|e| {
@@ -387,9 +409,7 @@ impl RtcPeerConnection {
     /// [`RtcPeerConnection::create_offer`] is automatically configured
     /// to trigger ICE restart.
     pub fn restart_ice(&self) {
-        unsafe {
-            peer_connection::restart_ice(self.handle.get());
-        }
+        unsafe { peer_connection::restart_ice(self.handle.get()) }.unwrap();
     }
 
     /// Sets provided [SDP offer][`SdpType::Offer`] as local description.
@@ -434,7 +454,9 @@ impl RtcPeerConnection {
     ///
     /// [1]: https://w3.org/TR/webrtc#dom-rtcpeerconnection-createanswer
     pub async fn create_answer(&self) -> RtcPeerConnectionResult<String> {
-        let fut = unsafe { peer_connection::create_answer(self.handle.get()) };
+        let fut = unsafe { peer_connection::create_answer(self.handle.get()) }
+            .unwrap();
+
         unsafe { FutureFromDart::execute(fut) }
             .await
             .map_err(RtcPeerConnectionError::CreateAnswerFailed)
@@ -450,7 +472,9 @@ impl RtcPeerConnection {
     ///
     /// [1]: https://w3.org/TR/webrtc#dom-peerconnection-setlocaldescription
     pub async fn rollback(&self) -> RtcPeerConnectionResult<()> {
-        let fut = unsafe { peer_connection::rollback(self.handle.get()) };
+        let fut =
+            unsafe { peer_connection::rollback(self.handle.get()) }.unwrap();
+
         unsafe { FutureFromDart::execute(fut) }
             .await
             .map_err(RtcPeerConnectionError::SetLocalDescriptionFailed)
@@ -469,7 +493,9 @@ impl RtcPeerConnection {
     ///
     /// [1]: https://w3.org/TR/webrtc#dom-rtcpeerconnection-createoffer
     pub async fn create_offer(&self) -> RtcPeerConnectionResult<String> {
-        let fut = unsafe { peer_connection::create_offer(self.handle.get()) };
+        let fut = unsafe { peer_connection::create_offer(self.handle.get()) }
+            .unwrap();
+
         unsafe { FutureFromDart::execute(fut) }
             .await
             .map_err(RtcPeerConnectionError::CreateOfferFailed)
@@ -499,14 +525,16 @@ impl RtcPeerConnection {
                     string_into_c_str(RtcSdpType::Offer.to_string()),
                     string_into_c_str(sdp),
                 )
-            },
+            }
+            .unwrap(),
             SdpType::Answer(sdp) => unsafe {
                 peer_connection::set_remote_description(
                     self.handle.get(),
                     string_into_c_str(RtcSdpType::Answer.to_string()),
                     string_into_c_str(sdp),
                 )
-            },
+            }
+            .unwrap(),
         };
         unsafe { FutureFromDart::execute::<()>(fut) }
             .await
@@ -530,7 +558,8 @@ impl RtcPeerConnection {
                 kind as i64,
                 init.handle(),
             )
-        };
+        }
+        .unwrap();
         let trnsvr: DartHandle =
             unsafe { FutureFromDart::execute(fut) }.await.unwrap();
         Transceiver::from(trnsvr)
@@ -552,7 +581,8 @@ impl RtcPeerConnection {
                     handle,
                     string_into_c_str(mid),
                 )
-            };
+            }
+            .unwrap();
             let transceiver: Option<DartHandle> =
                 unsafe { FutureFromDart::execute(fut) }.await.unwrap();
             transceiver.map(Transceiver::from)
@@ -571,7 +601,8 @@ impl RtcPeerConnection {
                 string_into_c_str(sdp_type.to_string()),
                 string_into_c_str(sdp),
             )
-        };
+        }
+        .unwrap();
         unsafe { FutureFromDart::execute(fut) }
             .await
             .map_err(RtcPeerConnectionError::SetLocalDescriptionFailed)
@@ -581,9 +612,7 @@ impl RtcPeerConnection {
 
 impl Drop for RtcPeerConnection {
     fn drop(&mut self) {
-        unsafe {
-            peer_connection::close(self.handle.get());
-        }
+        unsafe { peer_connection::close(self.handle.get()) }.unwrap();
     }
 }
 

--- a/src/platform/dart/send_encoding_parameters.rs
+++ b/src/platform/dart/send_encoding_parameters.rs
@@ -18,6 +18,8 @@ mod send_encoding_parameters {
 
     use dart_sys::Dart_Handle;
 
+    use crate::platform::Error;
+
     extern "C" {
         /// Creates new [RTCRtpEncodingParameters][0].
         ///
@@ -25,25 +27,33 @@ mod send_encoding_parameters {
         pub fn new_send_encoding_parameters(
             rid: ptr::NonNull<c_char>,
             active: bool,
-        ) -> Dart_Handle;
+        ) -> Result<Dart_Handle, Error>;
 
         /// Returns [RID] from the provided [RTCRtpEncodingParameters][0].
         ///
         /// [RID]: https://w3.org/TR/webrtc#dom-rtcrtpcodingparameters-rid
         /// [0]: https://w3.org/TR/webrtc#dom-rtcrtpencodingparameters
-        pub fn get_rid(encoding: Dart_Handle) -> ptr::NonNull<c_char>;
+        pub fn get_rid(
+            encoding: Dart_Handle,
+        ) -> Result<ptr::NonNull<c_char>, Error>;
 
         /// Sets [activeness][1] of the provided [RTCRtpEncodingParameters][0].
         ///
         /// [0]: https://w3.org/TR/webrtc#dom-rtcrtpencodingparameters
         /// [1]: https://w3.org/TR/webrtc#dom-rtcrtpencodingparameters-active
-        pub fn set_active(encoding: Dart_Handle, active: bool);
+        pub fn set_active(
+            encoding: Dart_Handle,
+            active: bool,
+        ) -> Result<(), Error>;
 
         /// Sets [maxBitrate][1] of the provided [RTCRtpEncodingParameters][0].
         ///
         /// [0]: https://w3.org/TR/webrtc#dom-rtcrtpencodingparameters
         /// [1]:https://w3.org/TR/webrtc#dom-rtcrtpencodingparameters-maxbitrate
-        pub fn set_max_bitrate(encoding: Dart_Handle, max_bitrate: i64);
+        pub fn set_max_bitrate(
+            encoding: Dart_Handle,
+            max_bitrate: i64,
+        ) -> Result<(), Error>;
 
         /// Sets [scaleResolutionDownBy][1] of the provided
         /// [RTCRtpEncodingParameters][0].
@@ -53,7 +63,7 @@ mod send_encoding_parameters {
         pub fn set_scale_resolution_down_by(
             encoding: Dart_Handle,
             scale_resolution_down_by: i64,
-        );
+        ) -> Result<(), Error>;
 
         /// Sets [scalabilityMode][1] of the provided
         /// [RTCRtpEncodingParameters][0].
@@ -63,7 +73,7 @@ mod send_encoding_parameters {
         pub fn set_scalability_mode(
             encoding: Dart_Handle,
             scalability_mode: ptr::NonNull<c_char>,
-        );
+        ) -> Result<(), Error>;
     }
 }
 
@@ -89,7 +99,8 @@ impl SendEncodingParameters {
                 string_into_c_str(rid),
                 active,
             )
-        };
+        }
+        .unwrap();
         Self(unsafe { DartHandle::new(handle) })
     }
 
@@ -106,7 +117,7 @@ impl SendEncodingParameters {
     #[must_use]
     pub fn rid(&self) -> String {
         let handle = self.0.get();
-        let rid = unsafe { send_encoding_parameters::get_rid(handle) };
+        let rid = unsafe { send_encoding_parameters::get_rid(handle) }.unwrap();
         unsafe { c_str_into_string(rid) }
     }
 
@@ -115,9 +126,8 @@ impl SendEncodingParameters {
     /// [1]: https://w3.org/TR/webrtc#dom-rtcrtpencodingparameters-active
     pub fn set_active(&mut self, active: bool) {
         let handle = self.0.get();
-        unsafe {
-            send_encoding_parameters::set_active(handle, active);
-        };
+        unsafe { send_encoding_parameters::set_active(handle, active) }
+            .unwrap();
     }
 
     /// Sets [maxBitrate][1] of these [`SendEncodingParameters`].
@@ -126,8 +136,9 @@ impl SendEncodingParameters {
     pub fn set_max_bitrate(&mut self, max_bitrate: i64) {
         let handle = self.0.get();
         unsafe {
-            send_encoding_parameters::set_max_bitrate(handle, max_bitrate);
-        };
+            send_encoding_parameters::set_max_bitrate(handle, max_bitrate)
+        }
+        .unwrap();
     }
 
     /// Sets [scaleResolutionDownBy][1] of these [`SendEncodingParameters`].
@@ -142,8 +153,9 @@ impl SendEncodingParameters {
             send_encoding_parameters::set_scale_resolution_down_by(
                 handle,
                 scale_resolution_down_by,
-            );
-        };
+            )
+        }
+        .unwrap();
     }
 
     /// Sets [scalabilityMode][1] of these [`SendEncodingParameters`].
@@ -155,8 +167,9 @@ impl SendEncodingParameters {
             send_encoding_parameters::set_scalability_mode(
                 handle,
                 string_into_c_str(scalability_mode.to_string()),
-            );
-        };
+            )
+        }
+        .unwrap();
     }
 }
 

--- a/src/platform/dart/transceiver.rs
+++ b/src/platform/dart/transceiver.rs
@@ -213,7 +213,6 @@ impl Transceiver {
         let handle = self.0.get();
         async move {
             let fut = unsafe { transceiver::get_direction(handle) }.unwrap();
-
             unsafe { FutureFromDart::execute::<i32>(fut) }
                 .await
                 .unwrap()
@@ -229,7 +228,6 @@ impl Transceiver {
         async move {
             let fut =
                 unsafe { transceiver::get_send_parameters(handle) }.unwrap();
-
             let params: DartHandle =
                 unsafe { FutureFromDart::execute(fut) }.await.unwrap();
             Parameters::from(params)
@@ -331,7 +329,6 @@ impl Drop for Transceiver {
             platform::spawn(async move {
                 let fut =
                     unsafe { transceiver::dispose(transceiver.get()) }.unwrap();
-
                 unsafe { FutureFromDart::execute::<()>(fut) }.await.unwrap();
             });
         }

--- a/src/platform/dart/transport.rs
+++ b/src/platform/dart/transport.rs
@@ -191,7 +191,6 @@ impl RpcTransport for WebSocketRpcTransport {
                 )
             }
             .unwrap();
-
             unsafe { FutureFromDart::execute::<DartHandle>(fut) }
         }
         .await
@@ -226,7 +225,6 @@ impl RpcTransport for WebSocketRpcTransport {
             TransportState::Open => unsafe {
                 let msg = serde_json::to_string(msg).unwrap();
                 transport::send(handle.get(), string_into_c_str(msg)).unwrap();
-
                 Ok(())
             },
             TransportState::Connecting

--- a/src/platform/dart/utils/callback.rs
+++ b/src/platform/dart/utils/callback.rs
@@ -22,16 +22,20 @@ mod callback {
 
     use dart_sys::Dart_Handle;
 
-    use crate::platform::dart::utils::callback::Callback;
+    use crate::platform::{dart::utils::callback::Callback, Error};
 
     extern "C" {
         /// Returns a [`Dart_Handle`] to a newly created Dart callback accepting
         /// 2 arguments that will proxy calls to the given Rust callback.
-        pub fn call_two_arg_proxy(cb: ptr::NonNull<Callback>) -> Dart_Handle;
+        pub fn call_two_arg_proxy(
+            cb: ptr::NonNull<Callback>,
+        ) -> Result<Dart_Handle, Error>;
 
         /// Returns a [`Dart_Handle`] to a newly created Dart callback that will
         /// proxy calls to the associated Rust callback.
-        pub fn call_proxy(cb: ptr::NonNull<Callback>) -> Dart_Handle;
+        pub fn call_proxy(
+            cb: ptr::NonNull<Callback>,
+        ) -> Result<Dart_Handle, Error>;
     }
 }
 
@@ -192,9 +196,9 @@ impl Callback {
 
         let f = ptr::NonNull::from(Box::leak(Box::new(self)));
         let handle = if is_two_arg {
-            unsafe { callback::call_two_arg_proxy(f) }
+            unsafe { callback::call_two_arg_proxy(f) }.unwrap()
         } else {
-            unsafe { callback::call_proxy(f) }
+            unsafe { callback::call_proxy(f) }.unwrap()
         };
 
         if is_finalizable {

--- a/src/platform/dart/utils/completer.rs
+++ b/src/platform/dart/utils/completer.rs
@@ -85,7 +85,6 @@ pub async fn delay_for(delay: Duration) {
     let delay = delay.as_millis() as i32;
     let delayed = unsafe { completer::delayed(delay) }.unwrap();
     let delayed_fut = unsafe { FutureFromDart::execute::<()>(delayed) };
-
     delayed_fut.await.unwrap();
 }
 
@@ -136,7 +135,6 @@ impl<T, E> Completer<T, E> {
     #[must_use]
     pub fn future(&self) -> Dart_Handle {
         let handle = unsafe { dart_api::handle_from_persistent(self.handle) };
-
         unsafe { completer::future(handle) }.unwrap()
     }
 }
@@ -154,7 +152,6 @@ impl<T: Into<DartValue>, E> Completer<T, E> {
     /// [Future]: https://api.dart.dev/dart-async/Future-class.html
     pub fn complete(&self, arg: T) {
         let handle = unsafe { dart_api::handle_from_persistent(self.handle) };
-
         unsafe { completer::complete(handle, arg.into()) }.unwrap();
     }
 }
@@ -165,7 +162,6 @@ impl<T> Completer<T, DartError> {
     /// [Future]: https://api.dart.dev/dart-async/Future-class.html
     pub fn complete_error(&self, e: DartError) {
         let handle = unsafe { dart_api::handle_from_persistent(self.handle) };
-
         unsafe { completer::complete_error(handle, e) }.unwrap();
     }
 }

--- a/src/platform/dart/utils/completer.rs
+++ b/src/platform/dart/utils/completer.rs
@@ -24,13 +24,16 @@ use crate::{
 mod completer {
     use dart_sys::Dart_Handle;
 
-    use crate::api::{utils::DartError, DartValue};
+    use crate::{
+        api::{utils::DartError, DartValue},
+        platform::Error,
+    };
 
     extern "C" {
         /// Returns a [`Dart_Handle`] to a new Dart [Completer].
         ///
         /// [Completer]: https://api.dart.dev/dart-async/Completer-class.html
-        pub fn init() -> Dart_Handle;
+        pub fn init() -> Result<Dart_Handle, Error>;
 
         /// Pointer to an extern function that invokes the [complete()] method
         /// with the provided [`DartValue`] on the provided
@@ -39,7 +42,7 @@ mod completer {
         /// [complete()]:
         /// https://api.dart.dev/dart-async/Completer/complete.html
         /// [Completer]: https://api.dart.dev/dart-async/Completer-class.html
-        pub fn complete(fut: Dart_Handle, val: DartValue);
+        pub fn complete(fut: Dart_Handle, val: DartValue) -> Result<(), Error>;
 
         /// Invokes the [completeError()][1] method with the provided
         /// [`DartError`] on the provided [`Dart_Handle`] pointing to the Dart
@@ -47,7 +50,10 @@ mod completer {
         ///
         /// [1]: https://api.dart.dev/dart-async/Completer/completeError.html
         /// [Completer]: https://api.dart.dev/dart-async/Completer-class.html
-        pub fn complete_error(fut: Dart_Handle, val: DartError);
+        pub fn complete_error(
+            fut: Dart_Handle,
+            val: DartError,
+        ) -> Result<(), Error>;
 
         /// Calls the [future] getter on the provided [`Dart_Handle`] pointing
         /// to the Dart [Completer] object.
@@ -58,11 +64,11 @@ mod completer {
         /// [future]: https://api.dart.dev/dart-async/Completer/future.html
         /// [Completer]: https://api.dart.dev/dart-async/Completer-class.html
         /// [Future]: https://api.dart.dev/dart-async/Future-class.html
-        pub fn future(fut: Dart_Handle) -> Dart_Handle;
+        pub fn future(fut: Dart_Handle) -> Result<Dart_Handle, Error>;
 
         /// Returns a [`Dart_Handle`] to the Dart `Future` waiting for the
         /// provided amount of time.
-        pub fn delayed(delay_ms: i32) -> Dart_Handle;
+        pub fn delayed(delay_ms: i32) -> Result<Dart_Handle, Error>;
     }
 }
 
@@ -77,8 +83,9 @@ mod completer {
 pub async fn delay_for(delay: Duration) {
     #[allow(clippy::cast_possible_truncation)]
     let delay = delay.as_millis() as i32;
-    let delayed = unsafe { completer::delayed(delay) };
+    let delayed = unsafe { completer::delayed(delay) }.unwrap();
     let delayed_fut = unsafe { FutureFromDart::execute::<()>(delayed) };
+
     delayed_fut.await.unwrap();
 }
 
@@ -113,7 +120,7 @@ impl<T, E> Completer<T, E> {
     /// [1]: https://api.dart.dev/dart-async/Completer-class.html
     #[must_use]
     pub fn new() -> Self {
-        let completer = unsafe { completer::init() };
+        let completer = unsafe { completer::init() }.unwrap();
         let handle = unsafe { dart_api::new_persistent_handle(completer) };
         Self {
             handle,
@@ -129,7 +136,8 @@ impl<T, E> Completer<T, E> {
     #[must_use]
     pub fn future(&self) -> Dart_Handle {
         let handle = unsafe { dart_api::handle_from_persistent(self.handle) };
-        unsafe { completer::future(handle) }
+
+        unsafe { completer::future(handle) }.unwrap()
     }
 }
 
@@ -146,9 +154,8 @@ impl<T: Into<DartValue>, E> Completer<T, E> {
     /// [Future]: https://api.dart.dev/dart-async/Future-class.html
     pub fn complete(&self, arg: T) {
         let handle = unsafe { dart_api::handle_from_persistent(self.handle) };
-        unsafe {
-            completer::complete(handle, arg.into());
-        }
+
+        unsafe { completer::complete(handle, arg.into()) }.unwrap();
     }
 }
 
@@ -158,8 +165,7 @@ impl<T> Completer<T, DartError> {
     /// [Future]: https://api.dart.dev/dart-async/Future-class.html
     pub fn complete_error(&self, e: DartError) {
         let handle = unsafe { dart_api::handle_from_persistent(self.handle) };
-        unsafe {
-            completer::complete_error(handle, e);
-        }
+
+        unsafe { completer::complete_error(handle, e) }.unwrap();
     }
 }

--- a/src/platform/dart/utils/dart_api.rs
+++ b/src/platform/dart/utils/dart_api.rs
@@ -192,7 +192,7 @@ pub unsafe fn get_error(handle: Dart_Handle) -> *const ffi::c_char {
 /// [1]: https://api.dart.dev/dart-ffi/NativeApi/initializeApiDLData.html
 pub unsafe fn propagate_error(mut handle: Dart_Handle) {
     let is_error = unsafe {
-        #[allow(clippy::expect_used)]
+        #[allow(clippy::expect_used)] // intentional
         Dart_IsError_DL.expect("`dart_api_dl` has not been initialized")
     };
 
@@ -200,7 +200,7 @@ pub unsafe fn propagate_error(mut handle: Dart_Handle) {
 
     if !is_error {
         let make_unhandled = unsafe {
-            #[allow(clippy::expect_used)]
+            #[allow(clippy::expect_used)] // intentional
             Dart_NewUnhandledExceptionError_DL
                 .expect("`dart_api_dl` has not been initialized")
         };
@@ -209,7 +209,7 @@ pub unsafe fn propagate_error(mut handle: Dart_Handle) {
     };
 
     let propagate = unsafe {
-        #[allow(clippy::expect_used)]
+        #[allow(clippy::expect_used)] // intentional
         Dart_PropagateError_DL.expect("`dart_api_dl` has not been initialized")
     };
     unsafe {

--- a/src/platform/dart/utils/dart_future.rs
+++ b/src/platform/dart/utils/dart_future.rs
@@ -27,7 +27,7 @@ mod future_from_dart {
 
     use dart_sys::Dart_Handle;
 
-    use crate::platform::dart::utils::dart_future::FutureFromDart;
+    use crate::platform::{dart::utils::dart_future::FutureFromDart, Error};
 
     /// Resolves the provided [Dart `Future`][0] with the provided
     /// [`FutureFromDart`].
@@ -37,7 +37,7 @@ mod future_from_dart {
         pub fn complete_proxy(
             fut: Dart_Handle,
             resolver: ptr::NonNull<FutureFromDart>,
-        );
+        ) -> Result<(), Error>;
     }
 }
 
@@ -128,8 +128,9 @@ impl FutureFromDart {
             future_from_dart::complete_proxy(
                 dart_fut.get(),
                 ptr::NonNull::from(Box::leak(Box::new(this))),
-            );
+            )
         }
+        .unwrap();
 
         async move { rx.await.unwrap() }
     }

--- a/src/platform/dart/utils/function.rs
+++ b/src/platform/dart/utils/function.rs
@@ -80,7 +80,7 @@ impl<T: Into<DartValue>> Function<T> {
     pub fn call1(&self, arg: T) {
         let fn_handle =
             unsafe { dart_api::handle_from_persistent(self.dart_fn) };
-        unsafe { function::caller(fn_handle, arg.into()) }.unwrap()
+        unsafe { function::caller(fn_handle, arg.into()) }.unwrap();
     }
 }
 

--- a/src/platform/dart/utils/function.rs
+++ b/src/platform/dart/utils/function.rs
@@ -21,11 +21,11 @@ use crate::{
 mod function {
     use dart_sys::Dart_Handle;
 
-    use crate::api::DartValue;
+    use crate::{api::DartValue, platform::Error};
 
     /// Invokes other Dart closures that accept a [`DartValue`] argument.
     extern "C" {
-        pub fn caller(f: Dart_Handle, val: DartValue);
+        pub fn caller(f: Dart_Handle, val: DartValue) -> Result<(), Error>;
     }
 }
 
@@ -80,9 +80,7 @@ impl<T: Into<DartValue>> Function<T> {
     pub fn call1(&self, arg: T) {
         let fn_handle =
             unsafe { dart_api::handle_from_persistent(self.dart_fn) };
-        unsafe {
-            function::caller(fn_handle, arg.into());
-        }
+        unsafe { function::caller(fn_handle, arg.into()) }.unwrap()
     }
 }
 

--- a/src/platform/dart/utils/handle.rs
+++ b/src/platform/dart/utils/handle.rs
@@ -80,7 +80,7 @@ impl DartHandle {
 }
 
 impl fmt::Display for DartHandle {
-    #[allow(clippy::unwrap_in_result)]
+    #[allow(clippy::unwrap_in_result)] // intentional
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let string = unsafe { handle::to_string(self.get()) }.unwrap();
         let string = unsafe { dart_string_into_rust(string) };

--- a/src/platform/dart/utils/handle.rs
+++ b/src/platform/dart/utils/handle.rs
@@ -75,7 +75,6 @@ impl DartHandle {
     #[must_use]
     pub fn name(&self) -> String {
         let type_name = unsafe { handle::runtime_type(self.get()) }.unwrap();
-
         unsafe { dart_string_into_rust(type_name) }
     }
 }

--- a/src/platform/dart/utils/handle.rs
+++ b/src/platform/dart/utils/handle.rs
@@ -81,6 +81,7 @@ impl DartHandle {
 }
 
 impl fmt::Display for DartHandle {
+    #[allow(clippy::unwrap_in_result)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let string = unsafe { handle::to_string(self.get()) }.unwrap();
         let string = unsafe { dart_string_into_rust(string) };

--- a/src/platform/dart/utils/handle.rs
+++ b/src/platform/dart/utils/handle.rs
@@ -16,13 +16,19 @@ mod handle {
 
     use dart_sys::Dart_Handle;
 
+    use crate::platform::Error;
+
     extern "C" {
         /// Returns a string representation of a Dart type behind the provided
         /// [`Dart_Handle`].
-        pub fn runtime_type(handle: Dart_Handle) -> ptr::NonNull<c_char>;
+        pub fn runtime_type(
+            handle: Dart_Handle,
+        ) -> Result<ptr::NonNull<c_char>, Error>;
 
         /// Returns a message of the provided Dart error.
-        pub fn to_string(handle: Dart_Handle) -> ptr::NonNull<c_char>;
+        pub fn to_string(
+            handle: Dart_Handle,
+        ) -> Result<ptr::NonNull<c_char>, Error>;
     }
 }
 
@@ -68,14 +74,15 @@ impl DartHandle {
     /// [`DartHandle`].
     #[must_use]
     pub fn name(&self) -> String {
-        let type_name = unsafe { handle::runtime_type(self.get()) };
+        let type_name = unsafe { handle::runtime_type(self.get()) }.unwrap();
+
         unsafe { dart_string_into_rust(type_name) }
     }
 }
 
 impl fmt::Display for DartHandle {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let string = unsafe { handle::to_string(self.get()) };
+        let string = unsafe { handle::to_string(self.get()) }.unwrap();
         let string = unsafe { dart_string_into_rust(string) };
         write!(f, "{string}")
     }

--- a/src/platform/dart/utils/list.rs
+++ b/src/platform/dart/utils/list.rs
@@ -68,7 +68,7 @@ impl DartList {
     /// Adds the provided [`DartValue`] to the end of this [`DartList`],
     /// extending the length by one.
     pub fn add(&mut self, value: DartValue) {
-        unsafe { list::add(self.0.get(), value) }.unwrap()
+        unsafe { list::add(self.0.get(), value) }.unwrap();
     }
 
     /// Returns an element by the provided `index` from this [`DartList`].

--- a/src/platform/dart/utils/list.rs
+++ b/src/platform/dart/utils/list.rs
@@ -100,7 +100,6 @@ impl<T: From<DartHandle>> From<DartList> for Vec<T> {
     fn from(list: DartList) -> Self {
         let len = list.length();
         let mut out = Self::with_capacity(len);
-
         for i in 0..len {
             if let Some(v) = list.get(i) {
                 out.push(v.into());

--- a/src/platform/dart/utils/map.rs
+++ b/src/platform/dart/utils/map.rs
@@ -16,13 +16,13 @@ mod map {
 
     use dart_sys::Dart_Handle;
 
-    use crate::api::DartValue;
+    use crate::{api::DartValue, platform::Error};
 
     extern "C" {
         /// Initializes a new empty [`Map`].
         ///
         /// [`Map`]: https://api.dart.dev/stable/dart-core/Map-class.html
-        pub fn init() -> Dart_Handle;
+        pub fn init() -> Result<Dart_Handle, Error>;
 
         /// Sets the provided `value` under the provided `key` to the provided
         /// [`Map`].
@@ -32,7 +32,7 @@ mod map {
             map: Dart_Handle,
             key: ptr::NonNull<c_char>,
             value: DartValue,
-        );
+        ) -> Result<(), Error>;
     }
 }
 
@@ -58,15 +58,15 @@ impl DartMap {
     /// Creates a new empty [`DartMap`].
     #[must_use]
     pub fn new() -> Self {
-        let map = unsafe { map::init() };
+        let map = unsafe { map::init() }.unwrap();
+
         Self(unsafe { DartHandle::new(map) })
     }
 
     /// Sets the provided `value` under the provided `key` to this [`DartMap`].
     pub fn set(&mut self, key: String, value: DartValue) {
-        unsafe {
-            map::set(self.0.get(), string_into_c_str(key), value);
-        }
+        unsafe { map::set(self.0.get(), string_into_c_str(key), value) }
+            .unwrap()
     }
 
     /// Returns the underlying [`Dart_Handle`] of this [`DartMap`].

--- a/src/platform/dart/utils/map.rs
+++ b/src/platform/dart/utils/map.rs
@@ -59,7 +59,6 @@ impl DartMap {
     #[must_use]
     pub fn new() -> Self {
         let map = unsafe { map::init() }.unwrap();
-
         Self(unsafe { DartHandle::new(map) })
     }
 

--- a/src/platform/dart/utils/map.rs
+++ b/src/platform/dart/utils/map.rs
@@ -66,7 +66,7 @@ impl DartMap {
     /// Sets the provided `value` under the provided `key` to this [`DartMap`].
     pub fn set(&mut self, key: String, value: DartValue) {
         unsafe { map::set(self.0.get(), string_into_c_str(key), value) }
-            .unwrap()
+            .unwrap();
     }
 
     /// Returns the underlying [`Dart_Handle`] of this [`DartMap`].


### PR DESCRIPTION
## Synopsis

Atm if Rust calls Dart and Dart throws an exception, Rust might not notice this and just continue execution. For example this happened in #174


## Solution

Modify `#[dart_bridge]` to wrap each function in try-catch and require all bindings to have a `Result` return.


## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
