### PR TITLE
Correctly propagate preferred video codecs on web platform

### DIFF
--- a/src/platform/wasm/transceiver.rs
+++ b/src/platform/wasm/transceiver.rs
@@ -192,7 +192,7 @@ impl Transceiver {
     /// Sets the preferred [`CodecCapability`]s for this [`Transceiver`].
     pub fn set_codec_preferences(&self, codecs: Vec<CodecCapability>) {
         let is_api_available =
-            get_property_by_name(&self.0, "set_codec_preferences", |val| {
+            get_property_by_name(&self.0, "setCodecPreferences", |val| {
                 if val.is_undefined() {
                     None
                 } else {
@@ -200,12 +200,14 @@ impl Transceiver {
                 }
             })
             .is_some();
+
+        // Unsupported on Firefox < 128.
         if is_api_available {
-            return;
-        }
-        let arr = ::js_sys::Array::new();
-        for codec in codecs {
-            _ = arr.push(codec.handle());
+            let arr = ::js_sys::Array::new();
+            for codec in codecs {
+                _ = arr.push(codec.handle());
+            }
+            self.0.set_codec_preferences(&arr);
         }
     }
 }


### PR DESCRIPTION
## Synopsis

`setCodecPreferences()` is not actually called on web platforms.




## Solution

Call `setCodecPreferences()` on web platforms.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
