### PR TITLE
Refactor `IceServer`'s password typing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,6 +2084,7 @@ dependencies = [
  "async-trait",
  "derive_more 1.0.0",
  "medea-macro",
+ "rand",
  "secrecy",
  "serde",
  "serde_with",

--- a/proto/client-api/CHANGELOG.md
+++ b/proto/client-api/CHANGELOG.md
@@ -40,7 +40,7 @@ All user visible changes to this project will be documented in this file. This p
 ## [0.6.0] · 2024-08-05
 [0.6.0]: /../../tree/medea-client-api-proto-0.6.0/proto/client-api
 
-## BC Breaks
+### BC Breaks
 
 - Added `PeerMetrics::PeerConnectionError` variant ([#151]).
 - Added `TrackPatchEvent::encoding_parameters` field ([#164]).
@@ -48,7 +48,7 @@ All user visible changes to this project will be documented in this file. This p
 - Fields of `RtcInboundRtpStreamMediaType`, `RtcOutboundRtpStreamMediaType` and `MediaKind` renamed in `camelCase` ([#173]).
 - Converted `frames_per_second` fields to `Float` instead of `u32`/`u64` ([#173]).
 
-## Added
+### Added
 
 - `PeerConnectionError` type ([#151]).
 - `IceCandidateError` type ([#151]).

--- a/proto/client-api/CHANGELOG.md
+++ b/proto/client-api/CHANGELOG.md
@@ -12,9 +12,14 @@ All user visible changes to this project will be documented in this file. This p
 ### BC Breaks
 
 - Made interior of `Credential` private. ([#189])
-- Made `IceServer::credential` to `Credential` instead of `String`. ([#189])
+- Made `IceServer::credential` to `IcePassword` instead of `String`. ([#189], [#190])
+
+### Added
+
+- `IcePassword` type ([#190]).
 
 [#189]: /../../pull/189
+[#190]: /../../pull/190
 
 
 

--- a/proto/client-api/Cargo.toml
+++ b/proto/client-api/Cargo.toml
@@ -26,7 +26,7 @@ extended-stats = []
 
 [dependencies]
 async-trait = { version = "0.1.34", optional = true }
-derive_more = { version = "1.0", features = ["constructor", "display", "from"] }
+derive_more = { version = "1.0", features = ["constructor", "display", "from", "into"] }
 medea-macro = { version = "0.3", path = "../../crates/medea-macro" }
 rand = "0.8"
 secrecy = { version = "0.10", features = ["serde"] }

--- a/proto/client-api/Cargo.toml
+++ b/proto/client-api/Cargo.toml
@@ -28,6 +28,7 @@ extended-stats = []
 async-trait = { version = "0.1.34", optional = true }
 derive_more = { version = "1.0", features = ["constructor", "display", "from"] }
 medea-macro = { version = "0.3", path = "../../crates/medea-macro" }
+rand = "0.8"
 secrecy = { version = "0.10", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "3.0"

--- a/proto/client-api/src/lib.rs
+++ b/proto/client-api/src/lib.rs
@@ -160,7 +160,7 @@ use std::{
 
 use derive_more::{Constructor, Display, From, Into};
 use medea_macro::dispatchable;
-use rand::{distributions::Alphanumeric, Rng};
+use rand::{distributions::Alphanumeric, Rng as _};
 use secrecy::{ExposeSecret as _, SecretString};
 use serde::{Deserialize, Serialize, Serializer};
 
@@ -194,15 +194,13 @@ pub struct PeerId(pub u32);
 )]
 pub struct TrackId(pub u32);
 
-/// Secret used for a client authentication on [`IceServer`].
+/// Secret used for a client authentication on an [`IceServer`].
 #[derive(Clone, Debug, Deserialize, From, Into)]
 pub struct IcePassword(SecretString);
 
 impl IcePassword {
-    /// Length of an [`IcePassword`] on a managed embedded [TURN] server.
-    ///
-    /// [TURN]: https://github.com/webrtc-rs/webrtc/tree/master/turn
-    pub const LENGTH: usize = 16;
+    /// Length of a randomly generated [`IcePassword`].
+    const RANDOM_LENGTH: usize = 16;
 
     /// Provides access to the underlying secret [`str`].
     #[must_use]
@@ -210,13 +208,13 @@ impl IcePassword {
         self.0.expose_secret()
     }
 
-    /// Generates a new random [`IcePassword`] for a user.
+    /// Generates a new random [`IcePassword`].
     #[must_use]
-    pub fn generate() -> Self {
+    pub fn random() -> Self {
         Self(
             rand::thread_rng()
                 .sample_iter(&Alphanumeric)
-                .take(Self::LENGTH)
+                .take(Self::RANDOM_LENGTH)
                 .map(char::from)
                 .collect::<String>()
                 .into(),


### PR DESCRIPTION
## Synopsis

We need to add the `IcePassword` type for more convenient ICE password typing.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
