### PR TITLE
Fix Chrome E2E tests running on Selenium Chrome image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1148,7 +1148,7 @@ docker-up-e2e-env = RUST_BACKTRACE=1 \
 	COMPOSE_WEBDRIVER_ENTRYPOINT=$(strip \
 		$(if $(call eq,$(browser),firefox),\
 			"geckodriver --binary=/opt/firefox/firefox" ,\
-			"sh -c \"/opt/bin/xvfb-run.sh 2>/dev/null & exec chromedriver --port=4444 --allowed-ips='' --allowed-origins='*'\"" ))
+			"sh -c \"/opt/bin/start-xvfb.sh 2>/dev/null & exec chromedriver --port=4444 --allowed-ips='' --allowed-origins='*'\"" ))
 
 docker.up.e2e: docker.down.e2e
 ifeq ($(rebuild),yes)
@@ -1210,7 +1210,7 @@ else
 	docker run --rm -d --network=host --shm-size 512m \
 		--name medea-webdriver-chrome --entrypoint sh \
 		selenium/standalone-chrome:$(CHROME_VERSION) \
-			-c "/opt/bin/xvfb-run.sh 2>/dev/null & exec chromedriver --port=4444 --allowed-ips='' --allowed-origins='*'"
+			-c "/opt/bin/start-xvfb.sh 2>/dev/null & exec chromedriver --port=4444 --allowed-ips='' --allowed-origins='*'"
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -1131,6 +1131,11 @@ docker.up.demo: docker.down.demo
 #	                   [( [background=no]
 #	                    | background=yes [log=(no|yes)] )]
 
+# You can add `/opt/bin/start-vnc.sh & /opt/bin/start-novnc.sh` after
+# `start-xvfb.sh` script in the `COMPOSE_WEBDRIVER_ENTRYPOINT` for chrome
+# start up VNC and a web client for it.
+# VNC web client (noVNC) can be accessed on this address:
+# http://localhost:7900/?autoconnect=1&resize=scale&password=secret
 docker-up-e2e-env = RUST_BACKTRACE=1 \
 	$(if $(call eq,$(log),yes),,RUST_LOG=warn) \
 	COMPOSE_MEDEA_IMAGE_NAME=hub.instrumentisto.com/streaming/medea$(if \
@@ -1207,6 +1212,10 @@ ifeq ($(browser),firefox)
 		ghcr.io/instrumentisto/geckodriver:$(FIREFOX_VERSION) \
 			--binary=/opt/firefox/firefox
 else
+	# You can add `/opt/bin/start-vnc.sh & /opt/bin/start-novnc.sh` after
+	# `start-xvfb.sh` script for starting up VNC and web client for it.
+	# VNC web client (noVNC) can be accessed on this address:
+	# http://localhost:7900/?autoconnect=1&resize=scale&password=secret
 	docker run --rm -d --network=host --shm-size 512m \
 		--name medea-webdriver-chrome --entrypoint sh \
 		selenium/standalone-chrome:$(CHROME_VERSION) \

--- a/Makefile
+++ b/Makefile
@@ -1121,6 +1121,12 @@ docker.up.demo: docker.down.demo
 
 # Run E2E tests environment in Docker Compose.
 #
+# For Chrome WebDriver:
+# `/opt/bin/start-vnc.sh & /opt/bin/start-novnc.sh` could be added after
+# `start-xvfb.sh` script for starting up VNC and web client for it.
+# VNC web client (noVNC) can be accessed on this address:
+# http://localhost:7900/?autoconnect=1&resize=scale&password=secret
+#
 # Usage:
 #	make docker.up.e2e [browser=(chrome|firefox)]
 #                      [rebuild=(no|yes)]
@@ -1131,11 +1137,6 @@ docker.up.demo: docker.down.demo
 #	                   [( [background=no]
 #	                    | background=yes [log=(no|yes)] )]
 
-# You can add `/opt/bin/start-vnc.sh & /opt/bin/start-novnc.sh` after
-# `start-xvfb.sh` script in the `COMPOSE_WEBDRIVER_ENTRYPOINT` for chrome
-# start up VNC and a web client for it.
-# VNC web client (noVNC) can be accessed on this address:
-# http://localhost:7900/?autoconnect=1&resize=scale&password=secret
 docker-up-e2e-env = RUST_BACKTRACE=1 \
 	$(if $(call eq,$(log),yes),,RUST_LOG=warn) \
 	COMPOSE_MEDEA_IMAGE_NAME=hub.instrumentisto.com/streaming/medea$(if \
@@ -1153,7 +1154,9 @@ docker-up-e2e-env = RUST_BACKTRACE=1 \
 	COMPOSE_WEBDRIVER_ENTRYPOINT=$(strip \
 		$(if $(call eq,$(browser),firefox),\
 			"geckodriver --binary=/opt/firefox/firefox" ,\
-			"sh -c \"/opt/bin/start-xvfb.sh 2>/dev/null & exec chromedriver --port=4444 --allowed-ips='' --allowed-origins='*'\"" ))
+			"sh -c \"/opt/bin/start-xvfb.sh 2>/dev/null & \
+			         exec chromedriver --port=4444 --allowed-ips='' \
+			                                       --allowed-origins='*'\"" ))
 
 docker.up.e2e: docker.down.e2e
 ifeq ($(rebuild),yes)
@@ -1200,6 +1203,12 @@ endif
 
 # Run dockerized WebDriver.
 #
+# For Chrome:
+# `/opt/bin/start-vnc.sh & /opt/bin/start-novnc.sh` could be added after
+# `start-xvfb.sh` script for starting up VNC and web client for it.
+# VNC web client (noVNC) can be accessed on this address:
+# http://localhost:7900/?autoconnect=1&resize=scale&password=secret
+#
 # Usage:
 #   make docker.up.webdriver [browser=(chrome|firefox)]
 
@@ -1212,14 +1221,12 @@ ifeq ($(browser),firefox)
 		ghcr.io/instrumentisto/geckodriver:$(FIREFOX_VERSION) \
 			--binary=/opt/firefox/firefox
 else
-	# You can add `/opt/bin/start-vnc.sh & /opt/bin/start-novnc.sh` after
-	# `start-xvfb.sh` script for starting up VNC and web client for it.
-	# VNC web client (noVNC) can be accessed on this address:
-	# http://localhost:7900/?autoconnect=1&resize=scale&password=secret
 	docker run --rm -d --network=host --shm-size 512m \
 		--name medea-webdriver-chrome --entrypoint sh \
 		selenium/standalone-chrome:$(CHROME_VERSION) \
-			-c "/opt/bin/start-xvfb.sh 2>/dev/null & exec chromedriver --port=4444 --allowed-ips='' --allowed-origins='*'"
+			-c "/opt/bin/start-xvfb.sh 2>/dev/null & \
+			    exec chromedriver --port=4444 --allowed-ips='' \
+			                                  --allowed-origins='*'"
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -1148,7 +1148,7 @@ docker-up-e2e-env = RUST_BACKTRACE=1 \
 	COMPOSE_WEBDRIVER_ENTRYPOINT=$(strip \
 		$(if $(call eq,$(browser),firefox),\
 			"geckodriver --binary=/opt/firefox/firefox" ,\
-			"chromedriver --port=4444 --allowed-ips='' --allowed-origins='*'" ))
+			"sh -c \"/opt/bin/xvfb-run.sh 2>/dev/null & exec chromedriver --port=4444 --allowed-ips='' --allowed-origins='*'\"" ))
 
 docker.up.e2e: docker.down.e2e
 ifeq ($(rebuild),yes)
@@ -1208,9 +1208,9 @@ ifeq ($(browser),firefox)
 			--binary=/opt/firefox/firefox
 else
 	docker run --rm -d --network=host --shm-size 512m \
-		--name medea-webdriver-chrome --entrypoint chromedriver \
+		--name medea-webdriver-chrome --entrypoint sh \
 		selenium/standalone-chrome:$(CHROME_VERSION) \
-			--port=4444 --allowed-ips='' --allowed-origins='*'
+			-c "/opt/bin/xvfb-run.sh 2>/dev/null & exec chromedriver --port=4444 --allowed-ips='' --allowed-origins='*'\""
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -1210,7 +1210,7 @@ else
 	docker run --rm -d --network=host --shm-size 512m \
 		--name medea-webdriver-chrome --entrypoint sh \
 		selenium/standalone-chrome:$(CHROME_VERSION) \
-			-c "/opt/bin/xvfb-run.sh 2>/dev/null & exec chromedriver --port=4444 --allowed-ips='' --allowed-origins='*'\""
+			-c "/opt/bin/xvfb-run.sh 2>/dev/null & exec chromedriver --port=4444 --allowed-ips='' --allowed-origins='*'"
 endif
 
 

--- a/e2e/.env
+++ b/e2e/.env
@@ -11,4 +11,4 @@ COMPOSE_CONTROL_MOCK_IMAGE_VER=dev
 COMPOSE_WEBDRIVER_IMAGE_NAME=selenium/standalone-chrome
 COMPOSE_WEBDRIVER_IMAGE_VER=latest
 
-COMPOSE_WEBDRIVER_ENTRYPOINT="chromedriver --port=4444 --allowed-ips='' --allowed-origins='*'"
+COMPOSE_WEBDRIVER_ENTRYPOINT="sh -c \"/opt/bin/xvfb-run.sh 2>/dev/null & exec chromedriver --port=4444 --allowed-ips='' --allowed-origins='*'\""

--- a/e2e/.env
+++ b/e2e/.env
@@ -11,8 +11,11 @@ COMPOSE_CONTROL_MOCK_IMAGE_VER=dev
 COMPOSE_WEBDRIVER_IMAGE_NAME=selenium/standalone-chrome
 COMPOSE_WEBDRIVER_IMAGE_VER=latest
 
-# You can add `/opt/bin/start-vnc.sh & /opt/bin/start-novnc.sh` after
+# `/opt/bin/start-vnc.sh & /opt/bin/start-novnc.sh` could be added after
 # `start-xvfb.sh` script for starting up VNC and web client for it.
 # VNC web client (noVNC) can be accessed on this address:
 # http://localhost:7900/?autoconnect=1&resize=scale&password=secret
-COMPOSE_WEBDRIVER_ENTRYPOINT="sh -c \"/opt/bin/start-xvfb.sh 2>/dev/null & exec chromedriver --port=4444 --allowed-ips='' --allowed-origins='*'\""
+COMPOSE_WEBDRIVER_ENTRYPOINT="sh -c \"/opt/bin/start-xvfb.sh 2>/dev/null & \
+                                      exec chromedriver --port=4444 \
+                                                        --allowed-ips='' \
+                                                        --allowed-origins='*'\""

--- a/e2e/.env
+++ b/e2e/.env
@@ -11,4 +11,8 @@ COMPOSE_CONTROL_MOCK_IMAGE_VER=dev
 COMPOSE_WEBDRIVER_IMAGE_NAME=selenium/standalone-chrome
 COMPOSE_WEBDRIVER_IMAGE_VER=latest
 
+# You can add `/opt/bin/start-vnc.sh & /opt/bin/start-novnc.sh` after
+# `start-xvfb.sh` script for starting up VNC and web client for it.
+# VNC web client (noVNC) can be accessed on this address:
+# http://localhost:7900/?autoconnect=1&resize=scale&password=secret
 COMPOSE_WEBDRIVER_ENTRYPOINT="sh -c \"/opt/bin/start-xvfb.sh 2>/dev/null & exec chromedriver --port=4444 --allowed-ips='' --allowed-origins='*'\""

--- a/e2e/.env
+++ b/e2e/.env
@@ -11,4 +11,4 @@ COMPOSE_CONTROL_MOCK_IMAGE_VER=dev
 COMPOSE_WEBDRIVER_IMAGE_NAME=selenium/standalone-chrome
 COMPOSE_WEBDRIVER_IMAGE_VER=latest
 
-COMPOSE_WEBDRIVER_ENTRYPOINT="sh -c \"/opt/bin/xvfb-run.sh 2>/dev/null & exec chromedriver --port=4444 --allowed-ips='' --allowed-origins='*'\""
+COMPOSE_WEBDRIVER_ENTRYPOINT="sh -c \"/opt/bin/start-xvfb.sh 2>/dev/null & exec chromedriver --port=4444 --allowed-ips='' --allowed-origins='*'\""

--- a/webdriver.json
+++ b/webdriver.json
@@ -9,6 +9,11 @@
   "goog:chromeOptions": {
     "args": [
       "--disable-dev-shm-usage",
+      "--disable-gpu",
+      "--disable-browser-side-navigation",
+      "--window-size=1920,1080",
+      "--disable-extensions",
+      "--dns-prefetch-disable",
       "--no-sandbox",
       "--use-fake-device-for-media-stream",
       "--use-fake-ui-for-media-stream"

--- a/webdriver.json
+++ b/webdriver.json
@@ -9,11 +9,6 @@
   "goog:chromeOptions": {
     "args": [
       "--disable-dev-shm-usage",
-      "--disable-gpu",
-      "--disable-browser-side-navigation",
-      "--window-size=1920,1080",
-      "--disable-extensions",
-      "--dns-prefetch-disable",
       "--no-sandbox",
       "--use-fake-device-for-media-stream",
       "--use-fake-ui-for-media-stream"

--- a/webdriver.json
+++ b/webdriver.json
@@ -8,15 +8,15 @@
   },
   "goog:chromeOptions": {
     "args": [
-      "--disable-dev-shm-usage",
-      "--disable-gpu",
       "--disable-browser-side-navigation",
-      "--window-size=1920,1080",
+      "--disable-dev-shm-usage",
       "--disable-extensions",
+      "--disable-gpu",
       "--dns-prefetch-disable",
       "--no-sandbox",
       "--use-fake-device-for-media-stream",
-      "--use-fake-ui-for-media-stream"
+      "--use-fake-ui-for-media-stream",
+      "--window-size=1920,1080"
     ]
   }
 }


### PR DESCRIPTION
## Synopsis

After migrating to `selenium/standalong-chrome` (https://github.com/instrumentisto/medea-jason/commit/b51c5e76aee25099cc25d7ebbd3e6ea804f0eb94 ) E2E tests not are not stable and error with:

```
Step panicked. Captured output: failed to initialize `World`: unexpected webdriver error: webdriver returned error: timeout: Timed out receiving message from renderer: 600.000
```




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
