### PR TITLE
Fix `NoSuchMethodError` thrown from `_getName()` Dart method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
  "serde",
@@ -672,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
 dependencies = [
  "jobserver",
  "libc",
@@ -877,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1037,9 +1037,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -1521,7 +1521,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1540,7 +1540,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1958,9 +1958,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -2151,9 +2151,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -2290,7 +2290,7 @@ dependencies = [
 
 [[package]]
 name = "medea-jason"
-version = "0.9.0"
+version = "0.9.1-dev"
 dependencies = [
  "android_logger",
  "async-recursion",
@@ -2380,9 +2380,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -2510,9 +2510,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openssl"
-version = "0.10.71"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2615,7 +2615,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
 ]
 
 [[package]]
@@ -2699,9 +2699,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
  "syn 2.0.100",
@@ -2845,9 +2845,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags",
 ]
@@ -3016,15 +3016,15 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.9.3",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.25"
+version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
+checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3239,7 +3239,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3265,7 +3265,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "itoa",
  "ryu",
  "serde",
@@ -3389,9 +3389,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "smart-default"
@@ -3681,9 +3681,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3803,7 +3803,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "medea-jason"
-version = "0.9.0"
+version = "0.9.1-dev"
 edition = "2024"
 rust-version = "1.85"
 description = "Client library for Medea media server."

--- a/flutter/CHANGELOG.md
+++ b/flutter/CHANGELOG.md
@@ -7,9 +7,9 @@ All user visible changes to this project will be documented in this file. This p
 
 
 ## [master] · unreleased
-[master]: /../../tree/master/flutter
+[master]: https://github.com/instrumentisto/medea-jason/tree/master/flutter
 
-See also [`medea-jason` crate `master` changes](/../../tree/master/CHANGELOG.md).
+See also [`medea-jason` crate `master` changes](https://github.com/instrumentisto/medea-jason/tree/master/CHANGELOG.md).
 
 ### Fixed
 

--- a/flutter/CHANGELOG.md
+++ b/flutter/CHANGELOG.md
@@ -6,6 +6,20 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [master] · unreleased
+[master]: /../../tree/master/flutter
+
+See also [`medea-jason` crate `master` changes](/../../tree/master/CHANGELOG.md).
+
+### Fixed
+
+- JavaScript to Dart exceptions conversion on WEB. ([#204])
+
+[#204]: https://github.com/instrumentisto/medea-jason/pull/204
+
+
+
+
 ## [0.9.0] · 2025-03-29
 [0.9.0]: https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.9.0/flutter
 

--- a/flutter/example/pubspec.lock
+++ b/flutter/example/pubspec.lock
@@ -250,6 +250,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  js_interop_utils:
+    dependency: transitive
+    description:
+      name: js_interop_utils
+      sha256: "7570549051ec66257b1a048aa5d614d757427398a84af7a2558a41f5c8cde5d6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.7"
   json_annotation:
     dependency: transitive
     description:
@@ -336,7 +344,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.9.0"
+    version: "0.9.1-dev"
   meta:
     dependency: transitive
     description:

--- a/flutter/lib/src/web/exceptions.dart
+++ b/flutter/lib/src/web/exceptions.dart
@@ -14,18 +14,15 @@ String? _getName(dynamic e) {
   }
 
   // TODO: Replace with more reliable way to determine whether [e] is a [JSAny]
-  //       when dart-lang/sdk#56905 is fixed:
+  //       once dart-lang/sdk#56905 is fixed:
   //       https://github.com/dart-lang/sdk/issues/56905
   final js = e.asJSAny;
-
   if (js == null) {
     return null;
   }
-
   if (!js.isA<JSObject>()) {
     return null;
   }
-
   js as JSObject;
 
   final constructor = js.getProperty('constructor'.toJS);

--- a/flutter/lib/src/web/exceptions.dart
+++ b/flutter/lib/src/web/exceptions.dart
@@ -1,4 +1,5 @@
 import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
 
 import '../interface/exceptions.dart';
 import 'jason_wasm.dart' as wasm;
@@ -7,16 +8,22 @@ import 'jason_wasm.dart' as wasm;
 ///
 /// Returns `null` in case if the provided exception is not from Jason.
 String? _getName(dynamic e) {
-  if (!e.isA<JSObject>()) {
-    return null;
-  }
+  if (e is JSAny) {
+    if (!e.isA<JSObject>()) {
+      return null;
+    }
 
-  final constructor = e.getProperty('constructor'.toJS);
-  if (constructor.isA<JSObject>()) {
-    if (constructor.hasProperty('name'.toJS).toDart) {
-      final name = constructor.getProperty('name'.toJS);
-      if (name.isA<JSString>()) {
-        return name.toDart;
+    e as JSObject;
+
+    final constructor = e.getProperty('constructor'.toJS);
+    if (constructor.isA<JSObject>()) {
+      constructor as JSObject;
+
+      if (constructor.hasProperty('name'.toJS).toDart) {
+        final name = constructor.getProperty('name'.toJS);
+        if (name.isA<JSString>()) {
+          return (name as JSString).toDart;
+        }
       }
     }
   }

--- a/flutter/lib/src/web/exceptions.dart
+++ b/flutter/lib/src/web/exceptions.dart
@@ -8,22 +8,31 @@ import 'jason_wasm.dart' as wasm;
 ///
 /// Returns `null` in case if the provided exception is not from Jason.
 String? _getName(dynamic e) {
-  if (e is JSAny) {
+  // This warning can be ignored due to this file being executed only in
+  // `dart2js` or `dart2wasm` environments, which have `JSAny` type in it.
+  // ignore: invalid_runtime_check_with_js_interop_types
+  if (e is! JSAny) {
+    return null;
+  }
+
+  try {
     if (!e.isA<JSObject>()) {
       return null;
     }
+  } on NoSuchMethodError {
+    return null;
+  }
 
-    e as JSObject;
+  e as JSObject;
 
-    final constructor = e.getProperty('constructor'.toJS);
-    if (constructor.isA<JSObject>()) {
-      constructor as JSObject;
+  final constructor = e.getProperty('constructor'.toJS);
+  if (constructor.isA<JSObject>()) {
+    constructor as JSObject;
 
-      if (constructor.hasProperty('name'.toJS).toDart) {
-        final name = constructor.getProperty('name'.toJS);
-        if (name.isA<JSString>()) {
-          return (name as JSString).toDart;
-        }
+    if (constructor.hasProperty('name'.toJS).toDart) {
+      final name = constructor.getProperty('name'.toJS);
+      if (name.isA<JSString>()) {
+        return (name as JSString).toDart;
       }
     }
   }

--- a/flutter/lib/src/web/exceptions.dart
+++ b/flutter/lib/src/web/exceptions.dart
@@ -1,5 +1,6 @@
-import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
+
+import 'package:js_interop_utils/js_interop_utils.dart';
 
 import '../interface/exceptions.dart';
 import 'jason_wasm.dart' as wasm;
@@ -8,24 +9,26 @@ import 'jason_wasm.dart' as wasm;
 ///
 /// Returns `null` in case if the provided exception is not from Jason.
 String? _getName(dynamic e) {
-  // This warning can be ignored due to this file being executed only in
-  // `dart2js` or `dart2wasm` environments, which have `JSAny` type in it.
-  // ignore: invalid_runtime_check_with_js_interop_types
-  if (e is! JSAny) {
+  if (e is! Object) {
     return null;
   }
 
-  try {
-    if (!e.isA<JSObject>()) {
-      return null;
-    }
-  } on NoSuchMethodError {
+  // TODO: Replace with more reliable way to determine whether [e] is a [JSAny]
+  //       when dart-lang/sdk#56905 is fixed:
+  //       https://github.com/dart-lang/sdk/issues/56905
+  final js = e.asJSAny;
+
+  if (js == null) {
     return null;
   }
 
-  e as JSObject;
+  if (!js.isA<JSObject>()) {
+    return null;
+  }
 
-  final constructor = e.getProperty('constructor'.toJS);
+  js as JSObject;
+
+  final constructor = js.getProperty('constructor'.toJS);
   if (constructor.isA<JSObject>()) {
     constructor as JSObject;
 

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: medea_jason
 description: Cross-platform client library of Medea media server for Flutter.
-version: 0.9.0
+version: 0.9.1-dev
 homepage: https://github.com/instrumentisto/medea-jason/blob/master/flutter
 
 environment:

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   flutter_rust_bridge: 2.9.0  # should be the same as in `Cargo.lock`
   freezed_annotation: ^2.4.4
   http: ">=0.13.6 <2.0.0"
+  js_interop_utils: ^1.0.7
   json_annotation: ^4.9.0
   medea_flutter_webrtc: ^0.13.3
   retry: ^3.1.2


### PR DESCRIPTION
## Synopsis

The following error can be thrown in a browser during any exceptions happening with media devices (for example, a device request being declined by user or by system):
```
 Uncaught (in promise) Error: NoSuchMethodError: 'isA'
Dynamic call of null.
Receiver: Instance of 'LegacyJavaScriptObject'
Arguments: []
    DartError dart_sdk.js:5717
    throw_ errors.dart:307
    defaultNoSuchMethod profile.dart:117
    noSuchMethod profile.dart:117
    callNSM operations.dart:472
    _checkAndCall operations.dart:487
    callMethod operations.dart:705
    dgsend profile.dart:117
    _getName exceptions.dart:10
    convertException exceptions.dart:29
    36asyncfallibleFuture exceptions.dart:79
    $protected dart_sdk.js:43125
    _wrapJsFunctionForAsync async_patch.dart:647
    errorCallback async_patch.dart:597
    runBinary zone.dart:1854
    handleError future_impl.dart:223
    handleError future_impl.dart:944
    _propagateToListeners future_impl.dart:965
    _completeError future_impl.dart:730
    _Future future_impl.dart:816
    _microtaskLoop schedule_microtask.dart:40
    _startMicrotaskLoop schedule_microtask.dart:49
    _scheduleImmediateWithPromise async_patch.dart:186
    promise callback*_scheduleImmediateWithPromise async_patch.dart:185
    _scheduleImmediate async_patch.dart:160
    _scheduleAsyncCallback schedule_microtask.dart:69
    _rootScheduleMicrotask zone.dart:1623
    scheduleMicrotask zone.dart:1869
    _asyncCompleteError future_impl.dart:815
    _completeError future_impl.dart:89
    completeError future_impl.dart:68
    error js_util_patch.dart:575
    promise callback*promiseToFuture js_util_patch.dart:578
    JSPromiseToFuture$124get$35toDart js_interop_patch.dart:161
    36asyncinitLocalTracks media_manager.dart:32
    $protected dart_sdk.js:43125
    _wrapJsFunctionForAsync async_patch.dart:647
    _asyncStartSync async_patch.dart:541
    initLocalTracks media_manager.dart:28
    36asyncgetTracks media_utils.dart:165
    $protected dart_sdk.js:43125
    _wrapJsFunctionForAsync async_patch.dart:647
    thenCallback async_patch.dart:593
    runUnary zone.dart:1849
    handleValue future_impl.dart:208
    handleValueCallback future_impl.dart:932
    _propagateToListeners future_impl.dart:961
    _Future future_impl.dart:535
    _microtaskLoop schedule_microtask.dart:40
    _startMicrotaskLoop schedule_microtask.dart:49
    _scheduleImmediateWithPromise async_patch.dart:186
    promise callback*_scheduleImmediateWithPromise async_patch.dart:185
    _scheduleImmediate async_patch.dart:160
    _scheduleAsyncCallback schedule_microtask.dart:69
    _rootScheduleMicrotask zone.dart:1623
    scheduleMicrotask zone.dart:1869
    _asyncCompleteWithValue future_impl.dart:791
    _asyncComplete future_impl.dart:751
    complete future_impl.dart:85
    success js_util_patch.dart:565
    promise callback*promiseToFuture js_util_patch.dart:578
    JSPromiseToFuture$124get$35toDart js_interop_patch.dart:161
```




## Solution

This happens due to this code:
```dart
String? _getName(dynamic e) {
  if (!e.isA<JSObject>()) {
    return null;
  }

  ...
}
```

Since `e` is a `dynamic`, it might not have a `isA()` method being available. Instead a casting of `is JSAny` should be made to ensure this method being available. This PR does exactly that as well as making some casts stricter through this method.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
