### PR TITLE
Pass `member_ids` to `ConnectionStateChanged` event

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -254,6 +254,11 @@ impl Connections {
         self.members_to_conns.borrow().get(remote_member_id).cloned()
     }
 
+    /// Lists all member IDs of [`Connections`].
+    pub fn member_ids(&self) -> Vec<MemberId> {
+        self.members_to_conns.borrow().keys().cloned().collect()
+    }
+
     /// Updates this [`Connection`] with the provided [`proto::state::Room`].
     pub fn apply(&self, new_state: &proto::state::Room) {
         #[expect(clippy::iter_over_hash_type, reason = "order doesn't matter")]

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -365,8 +365,8 @@ impl PeerConnection {
                 state.ice_servers().clone(),
                 state.force_relay(),
             )
-                .await
-                .map_err(tracerr::map_from_and_wrap!())?,
+            .await
+            .map_err(tracerr::map_from_and_wrap!())?,
         );
         let (track_events_sender, mut track_events_rx) = mpsc::unbounded();
         let media_connections = Rc::new(MediaConnections::new(
@@ -454,7 +454,8 @@ impl PeerConnection {
             self.peer.on_connection_state_change(Some(
                 move |peer_connection_state| {
                     if let Some(sender) = weak_sender.upgrade() {
-                        let member_ids = connections.upgrade()
+                        let member_ids = connections
+                            .upgrade()
                             .map(|connections| connections.member_ids())
                             .unwrap_or_default();
 
@@ -984,7 +985,7 @@ impl PeerConnection {
                             candidate.sdp_m_line_index,
                             &candidate.sdp_mid,
                         )
-                            .await
+                        .await
                     }
                 },
             ),

--- a/src/room.rs
+++ b/src/room.rs
@@ -519,7 +519,7 @@ impl RoomHandle {
             TrackDirection::Send,
             None,
         )
-            .map_err(tracerr::map_from_and_wrap!())
+        .map_err(tracerr::map_from_and_wrap!())
     }
 
     /// Unmutes outbound audio in this [`Room`].
@@ -541,7 +541,7 @@ impl RoomHandle {
             TrackDirection::Send,
             None,
         )
-            .map_err(tracerr::map_from_and_wrap!())
+        .map_err(tracerr::map_from_and_wrap!())
     }
 
     /// Mutes outbound video in this [`Room`].
@@ -564,7 +564,7 @@ impl RoomHandle {
             TrackDirection::Send,
             source_kind,
         )
-            .map_err(tracerr::map_from_and_wrap!())
+        .map_err(tracerr::map_from_and_wrap!())
     }
 
     /// Unmutes outbound video in this [`Room`].
@@ -587,7 +587,7 @@ impl RoomHandle {
             TrackDirection::Send,
             source_kind,
         )
-            .map_err(tracerr::map_from_and_wrap!())
+        .map_err(tracerr::map_from_and_wrap!())
     }
 
     /// Disables outbound audio in this [`Room`].
@@ -612,7 +612,7 @@ impl RoomHandle {
             TrackDirection::Send,
             None,
         )
-            .map_err(tracerr::map_from_and_wrap!())
+        .map_err(tracerr::map_from_and_wrap!())
     }
 
     /// Enables outbound audio in this [`Room`].
@@ -637,7 +637,7 @@ impl RoomHandle {
             TrackDirection::Send,
             None,
         )
-            .map_err(tracerr::map_from_and_wrap!())
+        .map_err(tracerr::map_from_and_wrap!())
     }
 
     /// Disables outbound video.
@@ -665,7 +665,7 @@ impl RoomHandle {
             TrackDirection::Send,
             source_kind,
         )
-            .map_err(tracerr::map_from_and_wrap!())
+        .map_err(tracerr::map_from_and_wrap!())
     }
 
     /// Enables outbound video.
@@ -693,7 +693,7 @@ impl RoomHandle {
             TrackDirection::Send,
             source_kind,
         )
-            .map_err(tracerr::map_from_and_wrap!())
+        .map_err(tracerr::map_from_and_wrap!())
     }
 
     /// Disables inbound audio in this [`Room`].
@@ -715,7 +715,7 @@ impl RoomHandle {
             TrackDirection::Recv,
             None,
         )
-            .map_err(tracerr::map_from_and_wrap!())
+        .map_err(tracerr::map_from_and_wrap!())
     }
 
     /// Disables inbound video in this [`Room`].
@@ -740,7 +740,7 @@ impl RoomHandle {
             TrackDirection::Recv,
             source_kind,
         )
-            .map_err(tracerr::map_from_and_wrap!())
+        .map_err(tracerr::map_from_and_wrap!())
     }
 
     /// Enables inbound audio in this [`Room`].
@@ -762,7 +762,7 @@ impl RoomHandle {
             TrackDirection::Recv,
             None,
         )
-            .map_err(tracerr::map_from_and_wrap!())
+        .map_err(tracerr::map_from_and_wrap!())
     }
 
     /// Enables inbound video in this [`Room`].
@@ -787,7 +787,7 @@ impl RoomHandle {
             TrackDirection::Recv,
             source_kind,
         )
-            .map_err(tracerr::map_from_and_wrap!())
+        .map_err(tracerr::map_from_and_wrap!())
     }
 }
 
@@ -1222,7 +1222,7 @@ impl InnerRoom {
                                     media_exchange_state::Stable::Enabled
                                 )
                             )
-                                .then_some(*track_id)
+                            .then_some(*track_id)
                         })
                         .collect(),
                 )
@@ -1259,9 +1259,9 @@ impl InnerRoom {
                 .collect::<Result<Vec<_>, Traced<ProhibitedStateError>>>()
                 .map_err(tracerr::map_from_and_wrap!())?,
         )
-            .await
-            .map(drop)
-            .map_err(tracerr::from_and_wrap!())?;
+        .await
+        .map(drop)
+        .map_err(tracerr::from_and_wrap!())?;
 
         future::try_join_all(stream_upd_sub.into_iter().filter_map(
             |(id, tracks_ids)| {
@@ -1273,10 +1273,10 @@ impl InnerRoom {
                 )
             },
         ))
-            .map(|r| r.map(drop))
-            .await
-            .map_err(tracerr::map_from_and_wrap!())
-            .map(drop)
+        .map(|r| r.map(drop))
+        .await
+        .map_err(tracerr::map_from_and_wrap!())
+        .map(drop)
     }
 
     /// Returns [`local::Track`]s for the provided [`MediaKind`] and
@@ -1454,12 +1454,12 @@ impl InnerRoom {
                             stop_first,
                             false,
                         )
-                            .await
-                            .map_err(|err| {
-                                err.recovery_failed(tracerr::map_from_and_wrap!()(
-                                    e.clone(),
-                                ))
-                            })?;
+                        .await
+                        .map_err(|err| {
+                            err.recovery_failed(tracerr::map_from_and_wrap!()(
+                                e.clone(),
+                            ))
+                        })?;
 
                         E::recovered(tracerr::map_from_and_wrap!()(e.clone()))
                     } else if stop_first {
@@ -1468,17 +1468,17 @@ impl InnerRoom {
                             criteria_kinds_diff,
                             states_update,
                         )
-                            .await
-                            .map_err(|err| {
-                                E::RecoverFailed {
-                                    recover_reason: tracerr::map_from_and_new!(
+                        .await
+                        .map_err(|err| {
+                            E::RecoverFailed {
+                                recover_reason: tracerr::map_from_and_new!(
                                     e.clone()
                                 ),
-                                    recover_fail_reasons: vec![
-                                        tracerr::map_from_and_new!(err),
-                                    ],
-                                }
-                            })?;
+                                recover_fail_reasons: vec![
+                                    tracerr::map_from_and_new!(err),
+                                ],
+                            }
+                        })?;
 
                         E::errored(tracerr::map_from_and_wrap!()(e.clone()))
                     } else {

--- a/src/room.rs
+++ b/src/room.rs
@@ -519,7 +519,7 @@ impl RoomHandle {
             TrackDirection::Send,
             None,
         )
-        .map_err(tracerr::map_from_and_wrap!())
+            .map_err(tracerr::map_from_and_wrap!())
     }
 
     /// Unmutes outbound audio in this [`Room`].
@@ -541,7 +541,7 @@ impl RoomHandle {
             TrackDirection::Send,
             None,
         )
-        .map_err(tracerr::map_from_and_wrap!())
+            .map_err(tracerr::map_from_and_wrap!())
     }
 
     /// Mutes outbound video in this [`Room`].
@@ -564,7 +564,7 @@ impl RoomHandle {
             TrackDirection::Send,
             source_kind,
         )
-        .map_err(tracerr::map_from_and_wrap!())
+            .map_err(tracerr::map_from_and_wrap!())
     }
 
     /// Unmutes outbound video in this [`Room`].
@@ -587,7 +587,7 @@ impl RoomHandle {
             TrackDirection::Send,
             source_kind,
         )
-        .map_err(tracerr::map_from_and_wrap!())
+            .map_err(tracerr::map_from_and_wrap!())
     }
 
     /// Disables outbound audio in this [`Room`].
@@ -612,7 +612,7 @@ impl RoomHandle {
             TrackDirection::Send,
             None,
         )
-        .map_err(tracerr::map_from_and_wrap!())
+            .map_err(tracerr::map_from_and_wrap!())
     }
 
     /// Enables outbound audio in this [`Room`].
@@ -637,7 +637,7 @@ impl RoomHandle {
             TrackDirection::Send,
             None,
         )
-        .map_err(tracerr::map_from_and_wrap!())
+            .map_err(tracerr::map_from_and_wrap!())
     }
 
     /// Disables outbound video.
@@ -665,7 +665,7 @@ impl RoomHandle {
             TrackDirection::Send,
             source_kind,
         )
-        .map_err(tracerr::map_from_and_wrap!())
+            .map_err(tracerr::map_from_and_wrap!())
     }
 
     /// Enables outbound video.
@@ -693,7 +693,7 @@ impl RoomHandle {
             TrackDirection::Send,
             source_kind,
         )
-        .map_err(tracerr::map_from_and_wrap!())
+            .map_err(tracerr::map_from_and_wrap!())
     }
 
     /// Disables inbound audio in this [`Room`].
@@ -715,7 +715,7 @@ impl RoomHandle {
             TrackDirection::Recv,
             None,
         )
-        .map_err(tracerr::map_from_and_wrap!())
+            .map_err(tracerr::map_from_and_wrap!())
     }
 
     /// Disables inbound video in this [`Room`].
@@ -740,7 +740,7 @@ impl RoomHandle {
             TrackDirection::Recv,
             source_kind,
         )
-        .map_err(tracerr::map_from_and_wrap!())
+            .map_err(tracerr::map_from_and_wrap!())
     }
 
     /// Enables inbound audio in this [`Room`].
@@ -762,7 +762,7 @@ impl RoomHandle {
             TrackDirection::Recv,
             None,
         )
-        .map_err(tracerr::map_from_and_wrap!())
+            .map_err(tracerr::map_from_and_wrap!())
     }
 
     /// Enables inbound video in this [`Room`].
@@ -787,7 +787,7 @@ impl RoomHandle {
             TrackDirection::Recv,
             source_kind,
         )
-        .map_err(tracerr::map_from_and_wrap!())
+            .map_err(tracerr::map_from_and_wrap!())
     }
 }
 
@@ -1222,7 +1222,7 @@ impl InnerRoom {
                                     media_exchange_state::Stable::Enabled
                                 )
                             )
-                            .then_some(*track_id)
+                                .then_some(*track_id)
                         })
                         .collect(),
                 )
@@ -1259,9 +1259,9 @@ impl InnerRoom {
                 .collect::<Result<Vec<_>, Traced<ProhibitedStateError>>>()
                 .map_err(tracerr::map_from_and_wrap!())?,
         )
-        .await
-        .map(drop)
-        .map_err(tracerr::from_and_wrap!())?;
+            .await
+            .map(drop)
+            .map_err(tracerr::from_and_wrap!())?;
 
         future::try_join_all(stream_upd_sub.into_iter().filter_map(
             |(id, tracks_ids)| {
@@ -1273,10 +1273,10 @@ impl InnerRoom {
                 )
             },
         ))
-        .map(|r| r.map(drop))
-        .await
-        .map_err(tracerr::map_from_and_wrap!())
-        .map(drop)
+            .map(|r| r.map(drop))
+            .await
+            .map_err(tracerr::map_from_and_wrap!())
+            .map(drop)
     }
 
     /// Returns [`local::Track`]s for the provided [`MediaKind`] and
@@ -1454,12 +1454,12 @@ impl InnerRoom {
                             stop_first,
                             false,
                         )
-                        .await
-                        .map_err(|err| {
-                            err.recovery_failed(tracerr::map_from_and_wrap!()(
-                                e.clone(),
-                            ))
-                        })?;
+                            .await
+                            .map_err(|err| {
+                                err.recovery_failed(tracerr::map_from_and_wrap!()(
+                                    e.clone(),
+                                ))
+                            })?;
 
                         E::recovered(tracerr::map_from_and_wrap!()(e.clone()))
                     } else if stop_first {
@@ -1468,17 +1468,17 @@ impl InnerRoom {
                             criteria_kinds_diff,
                             states_update,
                         )
-                        .await
-                        .map_err(|err| {
-                            E::RecoverFailed {
-                                recover_reason: tracerr::map_from_and_new!(
+                            .await
+                            .map_err(|err| {
+                                E::RecoverFailed {
+                                    recover_reason: tracerr::map_from_and_new!(
                                     e.clone()
                                 ),
-                                recover_fail_reasons: vec![
-                                    tracerr::map_from_and_new!(err),
-                                ],
-                            }
-                        })?;
+                                    recover_fail_reasons: vec![
+                                        tracerr::map_from_and_new!(err),
+                                    ],
+                                }
+                            })?;
 
                         E::errored(tracerr::map_from_and_wrap!()(e.clone()))
                     } else {
@@ -1790,12 +1790,13 @@ impl PeerEventHandler for InnerRoom {
         Ok(())
     }
 
-    /// Handles [`PeerEvent::ConnectionStateChanged`] event and sends new
+    /// Handles [`PeerEvent::PeerConnectionStateChanged`] event and sends new
     /// state to the RPC server.
-    async fn on_connection_state_changed(
+    async fn on_peer_connection_state_changed(
         &self,
         peer_id: PeerId,
         peer_connection_state: PeerConnectionState,
+        _member_ids: Vec<MemberId>,
     ) -> Self::Output {
         self.rpc.send_command(Command::AddPeerConnectionMetrics {
             peer_id,


### PR DESCRIPTION
Resolves #209 

## Synopsis

Add list of member ids to `PeerEventHandler::on_connection_state_changed()` to allow finding connections associated with `PeerConnection` state change.

## Solution

`member_ids` field added to `PeerConnectionStateChanged` event.

## Checklist

- Created PR:
    - [ ] In [draft mode][l:1]
    - [ ] Name contains issue reference
    - [ ] Has type and `k::` labels applied
    - [ ] Has assignee
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
