### PR TITLE
Rename `connection::ConnectionHandle` to `connection::ConnectionHandleImpl`

### DIFF
--- a/flutter/lib/src/native/ffi/frb/api/dart/api/connection_handle.dart
+++ b/flutter/lib/src/native/ffi/frb/api/dart/api/connection_handle.dart
@@ -42,7 +42,8 @@ abstract class ConnectionHandle implements RustOpaqueInterface, ForeignClass {
   ///
   /// # Errors
   ///
-  /// If the [`core::ConnectionHandle::get_remote_member_id()`] method errors.
+  /// If the [`core::ConnectionHandleImpl::get_remote_member_id()`] method
+  /// errors.
   String getRemoteMemberId();
 
   /// Sets a callback to be invoked once the associated [`Connection`] is
@@ -50,7 +51,7 @@ abstract class ConnectionHandle implements RustOpaqueInterface, ForeignClass {
   ///
   /// # Errors
   ///
-  /// If the [`core::ConnectionHandle::on_close()`] method errors.
+  /// If the [`core::ConnectionHandleImpl::on_close()`] method errors.
   void onClose({required Object f});
 
   /// Sets a callback to be invoked once a quality score of the associated
@@ -58,7 +59,7 @@ abstract class ConnectionHandle implements RustOpaqueInterface, ForeignClass {
   ///
   /// # Errors
   ///
-  /// If the [`core::ConnectionHandle::on_quality_score_update()`] method
+  /// If the [`core::ConnectionHandleImpl::on_quality_score_update()`] method
   /// errors.
   void onQualityScoreUpdate({required Object f});
 
@@ -67,7 +68,7 @@ abstract class ConnectionHandle implements RustOpaqueInterface, ForeignClass {
   ///
   /// # Errors
   ///
-  /// If the [`core::ConnectionHandle::on_remote_track_added()`] method
+  /// If the [`core::ConnectionHandleImpl::on_remote_track_added()`] method
   /// errors.
   ///
   /// [`remote::Track`]: media::track::remote::Track

--- a/flutter/lib/src/native/ffi/frb/frb_generated.dart
+++ b/flutter/lib/src/native/ffi/frb/frb_generated.dart
@@ -5588,7 +5588,8 @@ class ConnectionHandleImpl extends RustOpaque implements ConnectionHandle {
   ///
   /// # Errors
   ///
-  /// If the [`core::ConnectionHandle::get_remote_member_id()`] method errors.
+  /// If the [`core::ConnectionHandleImpl::get_remote_member_id()`] method
+  /// errors.
   String getRemoteMemberId() => RustLib.instance.api
       .crateApiDartApiConnectionHandleConnectionHandleGetRemoteMemberId(
         that: this,
@@ -5599,7 +5600,7 @@ class ConnectionHandleImpl extends RustOpaque implements ConnectionHandle {
   ///
   /// # Errors
   ///
-  /// If the [`core::ConnectionHandle::on_close()`] method errors.
+  /// If the [`core::ConnectionHandleImpl::on_close()`] method errors.
   void onClose({required Object f}) => RustLib.instance.api
       .crateApiDartApiConnectionHandleConnectionHandleOnClose(that: this, f: f);
 
@@ -5608,7 +5609,7 @@ class ConnectionHandleImpl extends RustOpaque implements ConnectionHandle {
   ///
   /// # Errors
   ///
-  /// If the [`core::ConnectionHandle::on_quality_score_update()`] method
+  /// If the [`core::ConnectionHandleImpl::on_quality_score_update()`] method
   /// errors.
   void onQualityScoreUpdate({required Object f}) => RustLib.instance.api
       .crateApiDartApiConnectionHandleConnectionHandleOnQualityScoreUpdate(
@@ -5621,7 +5622,7 @@ class ConnectionHandleImpl extends RustOpaque implements ConnectionHandle {
   ///
   /// # Errors
   ///
-  /// If the [`core::ConnectionHandle::on_remote_track_added()`] method
+  /// If the [`core::ConnectionHandleImpl::on_remote_track_added()`] method
   /// errors.
   ///
   /// [`remote::Track`]: media::track::remote::Track

--- a/src/api/dart/api/connection_handle.rs
+++ b/src/api/dart/api/connection_handle.rs
@@ -16,10 +16,10 @@ use crate::{connection::Connection, media::track::remote};
 /// External handler to a [`Connection`] with a remote `Member`.
 #[derive(Debug)]
 #[frb(opaque)]
-pub struct ConnectionHandle(SendWrapper<core::ConnectionHandle>);
+pub struct ConnectionHandle(SendWrapper<core::ConnectionHandleImpl>);
 
-impl From<core::ConnectionHandle> for ConnectionHandle {
-    fn from(value: core::ConnectionHandle) -> Self {
+impl From<core::ConnectionHandleImpl> for ConnectionHandle {
+    fn from(value: core::ConnectionHandleImpl) -> Self {
         Self(SendWrapper::new(value))
     }
 }
@@ -32,7 +32,7 @@ impl ConnectionHandle {
     ///
     /// # Errors
     ///
-    /// If the [`core::ConnectionHandle::on_close()`] method errors.
+    /// If the [`core::ConnectionHandleImpl::on_close()`] method errors.
     #[frb(sync)]
     pub fn on_close(&self, f: DartOpaque) -> Result<(), DartOpaque> {
         self.0
@@ -46,7 +46,7 @@ impl ConnectionHandle {
     ///
     /// # Errors
     ///
-    /// If the [`core::ConnectionHandle::on_remote_track_added()`] method
+    /// If the [`core::ConnectionHandleImpl::on_remote_track_added()`] method
     /// errors.
     ///
     /// [`remote::Track`]: media::track::remote::Track
@@ -66,7 +66,7 @@ impl ConnectionHandle {
     ///
     /// # Errors
     ///
-    /// If the [`core::ConnectionHandle::on_quality_score_update()`] method
+    /// If the [`core::ConnectionHandleImpl::on_quality_score_update()`] method
     /// errors.
     #[frb(sync)]
     pub fn on_quality_score_update(
@@ -83,7 +83,8 @@ impl ConnectionHandle {
     ///
     /// # Errors
     ///
-    /// If the [`core::ConnectionHandle::get_remote_member_id()`] method errors.
+    /// If the [`core::ConnectionHandleImpl::get_remote_member_id()`] method
+    /// errors.
     #[frb(sync)]
     pub fn get_remote_member_id(&self) -> Result<String, DartOpaque> {
         self.0

--- a/src/api/wasm/connection_handle.rs
+++ b/src/api/wasm/connection_handle.rs
@@ -14,7 +14,7 @@ use crate::{api, connection};
 /// upgraded.
 #[wasm_bindgen]
 #[derive(Debug, From)]
-pub struct ConnectionHandle(connection::ConnectionHandle);
+pub struct ConnectionHandle(connection::ConnectionHandleImpl);
 
 #[wasm_bindgen]
 impl ConnectionHandle {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -35,7 +35,7 @@ use crate::{
 #[derive(Caused, Clone, Copy, Debug, Display, From)]
 #[cause(error = platform::Error)]
 pub enum ChangeMediaStateError {
-    /// [`ConnectionHandle`]'s [`Weak`] pointer is detached.
+    /// [`ConnectionHandleImpl`]'s [`Weak`] pointer is detached.
     #[display("`ConnectionHandle` is in detached state")]
     Detached,
 
@@ -296,7 +296,7 @@ impl Connections {
     }
 }
 
-/// Error of [`ConnectionHandle`]'s [`Weak`] pointer being detached.
+/// Error of [`ConnectionHandleImpl`]'s [`Weak`] pointer being detached.
 #[derive(Caused, Clone, Copy, Debug, Display)]
 #[cause(error = platform::Error)]
 #[display("`ConnectionHandle` is in detached state")]
@@ -306,7 +306,7 @@ pub struct HandleDetachedError;
 ///
 /// Actually, represents a [`Weak`]-based handle to `InnerConnection`.
 #[derive(Clone, Debug)]
-pub struct ConnectionHandle(Weak<InnerConnection>);
+pub struct ConnectionHandleImpl(Weak<InnerConnection>);
 
 /// Estimated [`Connection`]'s quality on the client side only.
 #[derive(Clone, Copy, Debug, Display, Eq, From, Ord, PartialEq, PartialOrd)]
@@ -333,7 +333,8 @@ impl ClientConnectionQualityScore {
 
 /// Actual data of a connection with a specific remote `Member`.
 ///
-/// Shared between external [`ConnectionHandle`] and Rust side [`Connection`].
+/// Shared between external [`ConnectionHandleImpl`] and Rust side
+/// [`Connection`].
 #[derive(Debug)]
 struct InnerConnection {
     /// Remote `Member` ID.
@@ -417,7 +418,7 @@ impl InnerConnection {
     }
 }
 
-impl ConnectionHandle {
+impl ConnectionHandleImpl {
     /// Sets callback, invoked when this `Connection` will close.
     ///
     /// # Errors
@@ -487,8 +488,8 @@ impl ConnectionHandle {
     /// upgrade fails.
     ///
     /// With [`ChangeMediaStateError::TransitionIntoOppositeState`] if
-    /// [`ConnectionHandle::disable_remote_video()`] was called while enabling
-    /// or a media server didn't approve this state transition.
+    /// [`ConnectionHandleImpl::disable_remote_video()`] was called while
+    /// enabling or a media server didn't approve this state transition.
     pub fn enable_remote_video(
         &self,
         source_kind: Option<MediaSourceKind>,
@@ -508,8 +509,8 @@ impl ConnectionHandle {
     /// upgrade fails.
     ///
     /// With [`ChangeMediaStateError::TransitionIntoOppositeState`] if
-    /// [`ConnectionHandle::enable_remote_video()`] was called while disabling
-    /// or a media server didn't approve this state transition.
+    /// [`ConnectionHandleImpl::enable_remote_video()`] was called while
+    /// disabling or a media server didn't approve this state transition.
     pub fn disable_remote_video(
         &self,
         source_kind: Option<MediaSourceKind>,
@@ -529,8 +530,8 @@ impl ConnectionHandle {
     /// upgrade fails.
     ///
     /// With [`ChangeMediaStateError::TransitionIntoOppositeState`] if
-    /// [`ConnectionHandle::disable_remote_audio()`] was called while enabling
-    /// or a media server didn't approve this state transition.
+    /// [`ConnectionHandleImpl::disable_remote_audio()`] was called while
+    /// enabling or a media server didn't approve this state transition.
     pub fn enable_remote_audio(
         &self,
     ) -> impl Future<Output = ChangeMediaStateResult> + 'static + use<> {
@@ -549,8 +550,8 @@ impl ConnectionHandle {
     /// upgrade fails.
     ///
     /// With [`ChangeMediaStateError::TransitionIntoOppositeState`] if
-    /// [`ConnectionHandle::enable_remote_audio()`] was called while disabling
-    /// or a media server didn't approve this state transition.
+    /// [`ConnectionHandleImpl::enable_remote_audio()`] was called while
+    /// disabling or a media server didn't approve this state transition.
     pub fn disable_remote_audio(
         &self,
     ) -> impl Future<Output = ChangeMediaStateResult> + 'static + use<> {
@@ -692,8 +693,8 @@ impl Connection {
 
     /// Creates a new external handle to this [`Connection`].
     #[must_use]
-    pub fn new_handle(&self) -> ConnectionHandle {
-        ConnectionHandle(Rc::downgrade(&self.0))
+    pub fn new_handle(&self) -> ConnectionHandleImpl {
+        ConnectionHandleImpl(Rc::downgrade(&self.0))
     }
 
     /// Updates the [`ConnectionQualityScore`] of this [`Connection`].


### PR DESCRIPTION
Part of #217 

## Synopsis

`flutter_rust_bridge_codegen` can't see difference between `connection::ConnectionHandle` and `api::ConnectionHandle` thus generates warnings about randomly picking one from the pair.

## Solution

`connection::ConnectionHandle` can be rename to `connection::ConnectionHandleImpl` as it's the internal implementation that is used in API.

## Checklist

- Created PR:
    - [ ] In [draft mode][l:1]
    - [ ] Name contains issue reference
    - [ ] Has type and `k::` labels applied
    - [ ] Has assignee
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
