### PR TITLE
Rename `rpc::ReconnectHandle` to `rpc::ReconnectHandleImpl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,17 @@ All user visible changes to this project will be documented in this file. This p
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.10.0...master)
 
+### BC Breaks
+
+- Library API:
+    - Renamed `ReconnectHandle` to `ReconnectHandleImpl` ([#223]).
+
 ### Changed
 
 - `ConnectionHandle.onQualityScoreUpdate()` callback now receives `0` quality score if peer is disconnected. ([#212])
 
 [#212]: https://github.com/instrumentisto/medea-jason/pull/212
+[#223]: https://github.com/instrumentisto/medea-jason/pull/223
 
 
 

--- a/src/api/dart/api/reconnect_handle.rs
+++ b/src/api/dart/api/reconnect_handle.rs
@@ -18,10 +18,10 @@ use crate::{
 /// [`Room::on_connection_loss`]: super::RoomHandle::on_connection_loss
 #[derive(Debug)]
 #[frb(opaque)]
-pub struct ReconnectHandle(SendWrapper<core::ReconnectHandle>);
+pub struct ReconnectHandle(SendWrapper<core::ReconnectHandleImpl>);
 
-impl From<core::ReconnectHandle> for ReconnectHandle {
-    fn from(value: core::ReconnectHandle) -> Self {
+impl From<core::ReconnectHandleImpl> for ReconnectHandle {
+    fn from(value: core::ReconnectHandleImpl) -> Self {
         Self(SendWrapper::new(value))
     }
 }

--- a/src/api/wasm/reconnect_handle.rs
+++ b/src/api/wasm/reconnect_handle.rs
@@ -20,7 +20,7 @@ use crate::rpc;
 /// [`RoomHandle.on_connection_loss`]: crate::api::RoomHandle.on_connection_loss
 #[wasm_bindgen]
 #[derive(Clone, Debug, From)]
-pub struct ReconnectHandle(rpc::ReconnectHandle);
+pub struct ReconnectHandle(rpc::ReconnectHandleImpl);
 
 #[wasm_bindgen]
 impl ReconnectHandle {

--- a/src/room.rs
+++ b/src/room.rs
@@ -40,7 +40,8 @@ use crate::{
     platform,
     rpc::{
         ClientDisconnect, CloseReason, ConnectionInfo,
-        ConnectionInfoParseError, ReconnectHandle, RpcSession, SessionError,
+        ConnectionInfoParseError, ReconnectHandleImpl, RpcSession,
+        SessionError,
     },
     utils::{AsProtoState as _, Caused},
 };
@@ -1500,7 +1501,7 @@ impl InnerRoom {
     fn handle_rpc_connection_lost(&self) {
         self.peers.connection_lost();
         self.on_connection_loss
-            .call1(ReconnectHandle::new(Rc::downgrade(&self.rpc)));
+            .call1(ReconnectHandleImpl::new(Rc::downgrade(&self.rpc)));
     }
 
     /// Sends [`Command::SynchronizeMe`] with a current Client state to the

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -22,7 +22,7 @@ pub use self::rpc_session::MockRpcSession;
 pub use self::{
     backoff_delayer::BackoffDelayer,
     heartbeat::{Heartbeat, IdleTimeout, PingInterval},
-    reconnect_handle::{ReconnectError, ReconnectHandle},
+    reconnect_handle::{ReconnectError, ReconnectHandleImpl},
     rpc_session::{
         RpcSession, SessionError, SessionState, WebSocketRpcSession,
     },

--- a/src/rpc/reconnect_handle.rs
+++ b/src/rpc/reconnect_handle.rs
@@ -11,14 +11,14 @@ use crate::{
     utils::Caused,
 };
 
-/// Errors occurring in a [`ReconnectHandle`].
+/// Errors occurring in a [`ReconnectHandleImpl`].
 #[derive(Caused, Clone, Debug, From, Display)]
 #[cause(error = platform::Error)]
 pub enum ReconnectError {
     /// Some [`SessionError`] has occurred while reconnecting.
     Session(#[cause] SessionError),
 
-    /// [`ReconnectHandle`]'s [`Weak`] pointer is detached.
+    /// [`ReconnectHandleImpl`]'s [`Weak`] pointer is detached.
     #[display("ReconnectHandle is in detached state")]
     Detached,
 }
@@ -27,10 +27,10 @@ pub enum ReconnectError {
 ///
 /// This handle will be passed to a `Room.on_connection_loss` callback.
 #[derive(Clone, Debug)]
-pub struct ReconnectHandle(#[debug(skip)] Weak<dyn RpcSession>);
+pub struct ReconnectHandleImpl(#[debug(skip)] Weak<dyn RpcSession>);
 
-impl ReconnectHandle {
-    /// Instantiates new [`ReconnectHandle`] from the given [`RpcSession`]
+impl ReconnectHandleImpl {
+    /// Instantiates new [`ReconnectHandleImpl`] from the given [`RpcSession`]
     /// reference.
     #[must_use]
     pub fn new(rpc: Weak<dyn RpcSession>) -> Self {

--- a/src/rpc/rpc_session.rs
+++ b/src/rpc/rpc_session.rs
@@ -140,7 +140,7 @@ pub trait RpcSession {
     /// case of connection loss, client side user should select reconnection
     /// strategy with [`ReconnectHandle`] (or simply close [`Room`]).
     ///
-    /// [`ReconnectHandle`]: crate::rpc::ReconnectHandle
+    /// [`ReconnectHandle`]: crate::rpc::ReconnectHandleImpl
     /// [`Room`]: crate::room::Room
     fn on_connection_loss(&self) -> LocalBoxStream<'static, ()>;
 

--- a/src/rpc/websocket/client.rs
+++ b/src/rpc/websocket/client.rs
@@ -546,7 +546,7 @@ impl WebSocketRpcClient {
     /// case of connection loss, client side user should select reconnection
     /// strategy with [`ReconnectHandle`] (or simply close [`Room`]).
     ///
-    /// [`ReconnectHandle`]: crate::rpc::ReconnectHandle
+    /// [`ReconnectHandle`]: crate::rpc::ReconnectHandleImpl
     /// [`Room`]: crate::room::Room
     /// [`Stream`]: futures::Stream
     pub fn on_connection_loss(

--- a/tests/rpc/reconnect_handle.rs
+++ b/tests/rpc/reconnect_handle.rs
@@ -10,8 +10,8 @@ use medea_client_api_proto::{Event, ServerMsg};
 use medea_jason::{
     platform::{self, MockRpcTransport, RpcTransport, TransportState},
     rpc::{
-        CloseMsg, ConnectionInfo, ReconnectError, ReconnectHandle, RpcSession,
-        WebSocketRpcClient, WebSocketRpcSession,
+        CloseMsg, ConnectionInfo, ReconnectError, ReconnectHandleImpl,
+        RpcSession, WebSocketRpcClient, WebSocketRpcSession,
     },
 };
 use medea_reactive::ObservableCell;
@@ -21,7 +21,7 @@ use crate::{TEST_ROOM_URL, delay_for, rpc::RPC_SETTINGS, timeout};
 
 wasm_bindgen_test_configure!(run_in_browser);
 
-/// Makes sure that [`ReconnectHandle::reconnect_with_backoff()`] works as
+/// Makes sure that [`ReconnectHandleImpl::reconnect_with_backoff()`] works as
 /// expected.
 #[wasm_bindgen_test]
 async fn reconnect_with_backoff() {
@@ -62,8 +62,9 @@ async fn reconnect_with_backoff() {
 
     transport_state.set(TransportState::Closed(CloseMsg::Abnormal(999)));
     timeout(100, session.on_connection_loss().next()).await.unwrap().unwrap();
-    let handle =
-        ReconnectHandle::new(Rc::downgrade(&session) as Weak<dyn RpcSession>);
+    let handle = ReconnectHandleImpl::new(
+        Rc::downgrade(&session) as Weak<dyn RpcSession>
+    );
 
     // Checks that max_elapsed is not exceeded if starting_delay > max_elapsed.
     let start = instant::Instant::now();


### PR DESCRIPTION
Part of #217 

## Synopsis

`flutter_rust_bridge_codegen` can't see difference between `rpc::ReconnectHandle` and `api::ReconnectHandle` thus generates warnings about randomly picking one from the pair.

## Solution

 `rpc::ReconnectHandle` can be rename to  `rpc::ReconnectHandleImpl` as it's the internal implementation that is used in API.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
