### PR TITLE
Skip refreshing ClientConnectionQualityScore in SFU mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,25 +3,28 @@
 
 All user visible changes to this project will be documented in this file. This project uses [Semantic Versioning 2.0.0].
 
+
+
+
 ## master
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.11.0...master)
 
 ### Changed
 
-- `ConnectionHandle.onQualityScoreUpdate()` callback now is being called with `ConnectionQualityScore::High` when
-  `Connection` is in `SFU` mode. ([#228])
+- `ConnectionHandle.onQualityScoreUpdate()` callback now is being called with `ConnectionQualityScore::High` when `Connection` is in `SFU` mode. ([#228])
 
 [#228]: https://github.com/instrumentisto/medea-jason/pull/228
 
-## [0.11.0] · 2025-07-17
 
+
+
+## [0.11.0] · 2025-07-17
 [0.11.0]: https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.11.0
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.10.0...medea-jason-0.11.0)
 
-See also [
-`medea_jason` pub package 0.11.0 changes](https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.11.0/flutter/CHANGELOG.md).
+See also [`medea_jason` pub package 0.11.0 changes](https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.11.0/flutter/CHANGELOG.md).
 
 ### Changed
 
@@ -29,8 +32,10 @@ See also [
 
 [#212]: https://github.com/instrumentisto/medea-jason/pull/212
 
-## [0.10.0] · 2025-07-05
 
+
+
+## [0.10.0] · 2025-07-05
 [0.10.0]: https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.10.0
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.9.1...medea-jason-0.10.0)
@@ -38,38 +43,33 @@ See also [
 ### Added
 
 - Options to configure audio processing when creating local audio track: ([#206])
-    - `AudioTrackConstraints.exactEchoCancellation`, `AudioTrackConstraints.idealEchoCancellation` to configure echo
-      cancellation.
-    - `AudioTrackConstraints.exactNoiseSuppression`, `AudioTrackConstraints.idealNoiseSuppression`,
-      `AudioTrackConstraints.noiseSuppressionLevel` to configure noise suppression.
-    - `AudioTrackConstraints.exactHighPassFilter`, `AudioTrackConstraints.idealHighPassFilter` to configure high-pass
-      filter.
+    - `AudioTrackConstraints.exactEchoCancellation`, `AudioTrackConstraints.idealEchoCancellation` to configure echo cancellation.
+    - `AudioTrackConstraints.exactNoiseSuppression`, `AudioTrackConstraints.idealNoiseSuppression`, `AudioTrackConstraints.noiseSuppressionLevel` to configure noise suppression.
+    - `AudioTrackConstraints.exactHighPassFilter`, `AudioTrackConstraints.idealHighPassFilter` to configure high-pass filter.
 - Ability to inspect and configure audio processing for a audio `LocalMediaTrack` in runtime: ([#206])
     - `LocalMediaTrack.isAudioProcessingAvailable()` indicating if audio processing is available.
-    - `LocalMediaTrack.setNoiseSuppressionEnabled()`, `LocalMediaTrack.isNoiseSuppressionEnabled()` to inspect and
-      toggle noise suppression (supported on web and desktop platforms).
-    - `LocalMediaTrack.setEchoCancellationEnabled()`, `LocalMediaTrack.isEchoCancellationEnabled()` to inspect and
-      toggle echo cancellation (supported on web and desktop platforms).
-    - `LocalMediaTrack.setAutoGainControlEnabled()`, `LocalMediaTrack.isAutoGainControlEnabled()` to inspect and toggle
-      auto gain control (supported on web and desktop platforms).
-    - `LocalMediaTrack.setNoiseSuppressionLevel()`, `LocalMediaTrack.getNoiseSuppressionLevel()` to inspect and
-      configure noise suppression level (only supported on desktop platforms).
-    - `LocalMediaTrack.setHighPassFilterEnabled()`, `LocalMediaTrack.isHighPassFilterEnabledO()` to inspect and toggle
-      high-pass filter (only supported on desktop platforms).
+    - `LocalMediaTrack.setNoiseSuppressionEnabled()`, `LocalMediaTrack.isNoiseSuppressionEnabled()` to inspect and toggle noise suppression (supported on web and desktop platforms).
+    - `LocalMediaTrack.setEchoCancellationEnabled()`, `LocalMediaTrack.isEchoCancellationEnabled()` to inspect and toggle echo cancellation (supported on web and desktop platforms).
+    - `LocalMediaTrack.setAutoGainControlEnabled()`, `LocalMediaTrack.isAutoGainControlEnabled()` to inspect and toggle auto gain control (supported on web and desktop platforms).
+    - `LocalMediaTrack.setNoiseSuppressionLevel()`, `LocalMediaTrack.getNoiseSuppressionLevel()` to inspect and configure noise suppression level (only supported on desktop platforms).
+    - `LocalMediaTrack.setHighPassFilterEnabled()`, `LocalMediaTrack.isHighPassFilterEnabledO()` to inspect and toggle high-pass filter (only supported on desktop platforms).
 
 [#206]: https://github.com/instrumentisto/medea-jason/pull/206
 
-## [0.9.1] · 2025-04-11
 
+
+
+## [0.9.1] · 2025-04-11
 [0.9.1]: https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.9.1
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.9.0...medea-jason-0.9.1)
 
-See [
-`medea_jason` pub package 0.9.1 changes](https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.9.1/flutter/CHANGELOG.md).
+See [`medea_jason` pub package 0.9.1 changes](https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.9.1/flutter/CHANGELOG.md).
+
+
+
 
 ## [0.9.0] · 2025-03-29
-
 [0.9.0]: https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.9.0
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.8.0...medea-jason-0.9.0)
@@ -82,8 +82,7 @@ See [
 
 - Support of changing `RTCRtpSendParameters.encodings` via `Event::PeerUpdated`. ([#199])
 - Providing user agent media capabilities via `Command::JoinRoom`. ([#199])
-- `LocalMediaTrack.is_on_audio_level_available()` and `LocalMediaTrack.on_audio_level_changed()` support on
-  Web. ([#202], [#97], [#167])
+- `LocalMediaTrack.is_on_audio_level_available()` and `LocalMediaTrack.on_audio_level_changed()` support on Web. ([#202], [#97], [#167])
 
 ### Fixed
 
@@ -95,13 +94,13 @@ See [
     - Upgraded [`flutter_rust_bridge`] crate to 2.9.0 version. ([#203])
 
 [#199]: https://github.com/instrumentisto/medea-jason/pull/199
-
 [#202]: https://github.com/instrumentisto/medea-jason/pull/202
-
 [#203]: https://github.com/instrumentisto/medea-jason/pull/203
 
-## [0.8.0] · 2025-03-10
 
+
+
+## [0.8.0] · 2025-03-10
 [0.8.0]: https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.8.0
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.7.1...medea-jason-0.8.0)
@@ -121,17 +120,15 @@ See [
 - Segfault when closing [Flutter] application on macOS. ([#201])
 
 [#200]: https://github.com/instrumentisto/medea-jason/pull/200
-
 [#201]: https://github.com/instrumentisto/medea-jason/pull/200
-
 [3ed7d2bf]: https://github.com/instrumentisto/medea-jason/commit/3ed7d2bf59ed1237d9e55c4b65ea5cad833306fa
-
 [6f760c83]: https://github.com/instrumentisto/medea-jason/commit/6f760c836f9c5293b5fefae8a0cb4ee2bd5cfda2
-
 [080-1]: https://doc.rust-lang.org/edition-guide/rust-2024/index.html
 
-## [0.7.1] · 2024-12-30
 
+
+
+## [0.7.1] · 2024-12-30
 [0.7.1]: https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.7.1
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.7.0...medea-jason-0.7.1)
@@ -146,11 +143,12 @@ See [
     - [`flutter_rust_bridge`] to 2.7.0 version. ([#195])
 
 [#195]: https://github.com/instrumentisto/medea-jason/pull/195
-
 [#197]: https://github.com/instrumentisto/medea-jason/pull/197
 
-## [0.7.0] · 2024-10-29
 
+
+
+## [0.7.0] · 2024-10-29
 [0.7.0]: https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.7.0
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.6.1...medea-jason-0.7.0)
@@ -171,11 +169,12 @@ See [
     - [`flutter_rust_bridge`] to 2.4.0 version. ([#188])
 
 [#187]: https://github.com/instrumentisto/medea-jason/pull/187
-
 [#188]: https://github.com/instrumentisto/medea-jason/pull/188
 
-## [0.6.1] · 2024-09-11
 
+
+
+## [0.6.1] · 2024-09-11
 [0.6.1]: https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.6.1
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.6.0...medea-jason-0.6.1)
@@ -186,8 +185,10 @@ See [
 
 [fe29ee20]: https://github.com/instrumentisto/medea-jason/commit/fe29ee20b7dd210145a2004ebe8389140aec10a3
 
-## [0.6.0] · 2024-08-27
 
+
+
+## [0.6.0] · 2024-08-27
 [0.6.0]: https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.6.0
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.5.0...medea-jason-0.6.0)
@@ -203,13 +204,13 @@ See [
     - [`flutter_rust_bridge`] to 2.2.0 version. ([#182])
 
 [#180]: https://github.com/instrumentisto/medea-jason/pull/180
-
 [#181]: https://github.com/instrumentisto/medea-jason/pull/181
-
 [#182]: https://github.com/instrumentisto/medea-jason/pull/182
 
-## [0.5.0] · 2024-08-05
 
+
+
+## [0.5.0] · 2024-08-05
 [0.5.0]: https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.5.0
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.4.0...medea-jason-0.5.0)
@@ -218,8 +219,7 @@ See [
 
 - Minimal supported version of [`medea-client-api-proto`] is `0.6.0` ([#151]).
 - Library API:
-    - Removed `with_rpc_client()` constructor and added `WebSocketRpcClient` as argument to `new()` constructor in
-      `Jason` ([#175]).
+    - Removed `with_rpc_client()` constructor and added `WebSocketRpcClient` as argument to `new()` constructor in `Jason` ([#175]).
 
 ### Added
 
@@ -242,27 +242,20 @@ See [
 - Exception in Dart code might be ignored by Rust caller ([#176]).
 
 [#135]: https://github.com/instrumentisto/medea-jason/pull/135
-
 [#138]: https://github.com/instrumentisto/medea-jason/pull/138
-
 [#151]: https://github.com/instrumentisto/medea-jason/pull/151
-
 [#162]: https://github.com/instrumentisto/medea-jason/pull/162
-
 [#163]: https://github.com/instrumentisto/medea-jason/pull/163
-
 [#166]: https://github.com/instrumentisto/medea-jason/pull/166
-
 [#167]: https://github.com/instrumentisto/medea-jason/pull/167
-
 [#172]: https://github.com/instrumentisto/medea-jason/pull/172
-
 [#175]: https://github.com/instrumentisto/medea-jason/pull/175
-
 [#176]: https://github.com/instrumentisto/medea-jason/pull/176
 
-## [0.4.0] · 2023-07-11
 
+
+
+## [0.4.0] · 2023-07-11
 [0.4.0]: https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.4.0
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.3.0...medea-jason-0.4.0)
@@ -278,8 +271,10 @@ See [
 
 [#119]: https://github.com/instrumentisto/medea-jason/pull/119
 
-## [0.3.0] · 2023-06-09
 
+
+
+## [0.3.0] · 2023-06-09
 [0.3.0]: https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.3.0
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/a2ce6b92...medea-jason-0.3.0)
@@ -287,8 +282,7 @@ See [
 ### BC Breaks
 
 - Library API:
-    - `ReconnectHandle.reconnect_with_backoff()` now performs first reconnect attempt
-      immediately ([instrumentisto/medea#206]).
+    - `ReconnectHandle.reconnect_with_backoff()` now performs first reconnect attempt immediately ([instrumentisto/medea#206]).
     - Removed `JasonError` and changed thrown exceptions kind ([#4]):
         - `ConnectionHandle`:
             - `on_close` - `StateError`;
@@ -336,8 +330,7 @@ See [
         - `MediaStateTransitionException`;
         - `MediaSettingsUpdateException`.
     - `MediaManagerHandle.set_output_audio_id()` method switching output audio device on Dart platform ([#29]);
-    - `MediaManagerHandle.on_device_change()` callback firing whenever `MediaManagerHandle.enumerate_devices()` list
-      changes ([#30]);
+    - `MediaManagerHandle.on_device_change()` callback firing whenever `MediaManagerHandle.enumerate_devices()` list changes ([#30]);
     - `ConnectionHandle` methods ([#43], [#59]):
         - `enable_remote_video`;
         - `disable_remote_video`;
@@ -367,51 +360,32 @@ See [
 - Switch to [2021 Rust edition][012-1] ([#16]).
 
 [instrumentisto/medea#206]: https://github.com/instrumentisto/medea/pull/206
-
 [#4]: https://github.com/instrumentisto/medea-jason/pull/4
-
 [#8]: https://github.com/instrumentisto/medea-jason/pull/8
-
 [#9]: https://github.com/instrumentisto/medea-jason/pull/9
-
 [#10]: https://github.com/instrumentisto/medea-jason/pull/10
-
 [#12]: https://github.com/instrumentisto/medea-jason/pull/12
-
 [#14]: https://github.com/instrumentisto/medea-jason/pull/14
-
 [#16]: https://github.com/instrumentisto/medea-jason/pull/16
-
 [#26]: https://github.com/instrumentisto/medea-jason/pull/26
-
 [#28]: https://github.com/instrumentisto/medea-jason/pull/28
-
 [#29]: https://github.com/instrumentisto/medea-jason/pull/29
-
 [#30]: https://github.com/instrumentisto/medea-jason/pull/30
-
 [#31]: https://github.com/instrumentisto/medea-jason/pull/31
-
 [#43]: https://github.com/instrumentisto/medea-jason/pull/43
-
 [#46]: https://github.com/instrumentisto/medea-jason/pull/46
-
 [#49]: https://github.com/instrumentisto/medea-jason/pull/49
-
 [#52]: https://github.com/instrumentisto/medea-jason/pull/52
-
 [#57]: https://github.com/instrumentisto/medea-jason/pull/57
-
 [#59]: https://github.com/instrumentisto/medea-jason/pull/59
-
 [#81]: https://github.com/instrumentisto/medea-jason/pull/81
-
 [#106]: https://github.com/instrumentisto/medea-jason/pull/106
-
 [#106]: https://github.com/instrumentisto/medea-jason/pull/109
 
-## [0.2.0] · 2021-04-09
 
+
+
+## [0.2.0] · 2021-04-09
 [0.2.0]: https://github.com/instrumentisto/medea/tree/medea-jason-0.2.0/jason
 
 [Diff](https://github.com/instrumentisto/medea/compare/medea-jason-0.1.0...medea-jason-0.2.0) | [Milestone](https://github.com/instrumentisto/medea/milestone/2) | [Roadmap](https://github.com/instrumentisto/medea/issues/27)
@@ -443,8 +417,7 @@ See [
         - Local media stream constraints:
             - `MediaStreamSettings`, `AudioTrackConstraints` classes ([#46], [#97]);
             - `DeviceVideoTrackConstraints`, `DisplayVideoTrackConstraints` classes ([#78]);
-            - `DeviceVideoTrackConstraints.ideal_facing_mode` and `DeviceVideoTrackConstraints.exact_facing_mode`
-              functions ([#137]);
+            - `DeviceVideoTrackConstraints.ideal_facing_mode` and `DeviceVideoTrackConstraints.exact_facing_mode` functions ([#137]);
             - `DeviceVideoTrackConstraints` width and height configuration ([#158]):
                 - `DeviceVideoTrackConstraints.ideal_width`;
                 - `DeviceVideoTrackConstraints.exact_width`;
@@ -459,22 +432,16 @@ See [
             - `Jason.init_room()` ([#46]);
             - `Room.join()` ([#46]);
             - `Jason.close_room()` ([#147]).
-        - Ability to configure local media stream used by `Room` via
-          `Room.set_local_media_settings()` ([#54], [#97], [#145], [#160]):
-            - `Room.set_local_media_settings()` can be configured to stop used tracks before trying to acquire new
-              tracks ([#160]);
-            - `Room.set_local_media_settings()` can be configured to rollback to previous settings if fail to set new
-              settings ([#160]).
+        - Ability to configure local media stream used by `Room` via `Room.set_local_media_settings()` ([#54], [#97], [#145], [#160]):
+            - `Room.set_local_media_settings()` can be configured to stop used tracks before trying to acquire new tracks ([#160]);
+            - `Room.set_local_media_settings()` can be configured to rollback to previous settings if fail to set new settings ([#160]).
         - `Room.on_failed_local_media` callback ([#54], [#143]);
         - `Room.on_close` callback for WebSocket close initiated by server ([#55]);
-        - `RemoteMediaTrack.on_enabled` and `RemoteMediaTrack.on_disabled` callbacks being called when
-          `RemoteMediaTrack` is enabled or disabled ([#123], [#143], [#156]);
+        - `RemoteMediaTrack.on_enabled` and `RemoteMediaTrack.on_disabled` callbacks being called when `RemoteMediaTrack` is enabled or disabled ([#123], [#143], [#156]);
         - `RemoteMediaTrack.on_stopped` callback that is called when `RemoteMediaTrack` is stopped ([#109]);
-        - `RemoteMediaTrack.on_muted` and `RemoteMediaTrack.on_unmuted` callbacks being called when `RemoteMediaTrack`
-          is muted or unmuted ([#191]);
+        - `RemoteMediaTrack.on_muted` and `RemoteMediaTrack.on_unmuted` callbacks being called when `RemoteMediaTrack` is muted or unmuted ([#191]);
         - `RemoteMediaTrack.muted()` method indicating whether this `RemoteMediaTrack` is muted ([#191]);
-        - `ConnectionHandle.on_remote_track_added` callback being called when new receiver `RemoteMediaTrack` is
-          added ([#123], [#143], [#156]);
+        - `ConnectionHandle.on_remote_track_added` callback being called when new receiver `RemoteMediaTrack` is added ([#123], [#143], [#156]);
         - Enabling/disabling remote video/audio ([#127], [#155]):
             - `Room.disable_remote_audio`;
             - `Room.enable_remote_audio`;
@@ -509,8 +476,7 @@ See [
         - Enabling/disabling audio/video send/receive via `UpdateTracks` command ([#81], [#155]);
         - Muting/unmuting audio/video send via `UpdateTracks` ([#156]).
     - Handling of RPC events:
-        - `PeerUpdated` with `PeerUpdate::Added`, `PeerUpdate::Updated`, `PeerUpdate::IceRestart` and
-          `PeerUpdate::Removed` ([#105], [#138], [#139], [#109]);
+        - `PeerUpdated` with `PeerUpdate::Added`, `PeerUpdate::Updated`, `PeerUpdate::IceRestart` and `PeerUpdate::Removed` ([#105], [#138], [#139], [#109]);
         - `ConnectionQualityUpdated` ([#132]).
 - Error handling:
     - Library API:
@@ -522,77 +488,45 @@ See [
     - Skipped `IceCandidate`s received before receiving remote SDP ([#50]).
 
 [#40]: https://github.com/instrumentisto/medea/pull/40
-
 [#46]: https://github.com/instrumentisto/medea/pull/46
-
 [#50]: https://github.com/instrumentisto/medea/pull/59
-
 [#54]: https://github.com/instrumentisto/medea/pull/54
-
 [#55]: https://github.com/instrumentisto/medea/pull/55
-
 [#71]: https://github.com/instrumentisto/medea/pull/71
-
 [#75]: https://github.com/instrumentisto/medea/pull/75
-
 [#78]: https://github.com/instrumentisto/medea/pull/78
-
 [#79]: https://github.com/instrumentisto/medea/pull/79
-
 [#81]: https://github.com/instrumentisto/medea/pull/81
-
 [#87]: https://github.com/instrumentisto/medea/pull/87
-
 [#90]: https://github.com/instrumentisto/medea/pull/90
-
 [#97]: https://github.com/instrumentisto/medea/pull/97
-
 [#105]: https://github.com/instrumentisto/medea/pull/105
-
 [#106]: https://github.com/instrumentisto/medea/pull/106
-
 [#109]: https://github.com/instrumentisto/medea/pull/109
-
 [#120]: https://github.com/instrumentisto/medea/pull/120
-
 [#123]: https://github.com/instrumentisto/medea/pull/123
-
 [#124]: https://github.com/instrumentisto/medea/pull/124
-
 [#127]: https://github.com/instrumentisto/medea/pull/127
-
 [#132]: https://github.com/instrumentisto/medea/pull/132
-
 [#137]: https://github.com/instrumentisto/medea/pull/137
-
 [#138]: https://github.com/instrumentisto/medea/pull/138
-
 [#139]: https://github.com/instrumentisto/medea/pull/139
-
 [#143]: https://github.com/instrumentisto/medea/pull/143
-
 [#144]: https://github.com/instrumentisto/medea/pull/144
-
 [#145]: https://github.com/instrumentisto/medea/pull/145
-
 [#146]: https://github.com/instrumentisto/medea/pull/146
-
 [#147]: https://github.com/instrumentisto/medea/pull/147
-
 [#155]: https://github.com/instrumentisto/medea/pull/155
-
 [#156]: https://github.com/instrumentisto/medea/pull/156
-
 [#158]: https://github.com/instrumentisto/medea/pull/158
-
 [#160]: https://github.com/instrumentisto/medea/pull/160
-
 [#167]: https://github.com/instrumentisto/medea/pull/167
-
 [#191]: https://github.com/instrumentisto/medea/pull/191
 
-## [0.1.0] · 2019-08-21
 
+
+
+## [0.1.0] · 2019-08-21
 [0.1.0]: https://github.com/instrumentisto/medea/tree/medea-jason-0.1.0/jason
 
 [Milestone](https://github.com/instrumentisto/medea/milestone/1) | [Roadmap](https://github.com/instrumentisto/medea/issues/8)
@@ -608,7 +542,7 @@ See [
 - Ability to use ICE servers provided by server ([#20]).
 - Signalling ([#22]):
     - Library API:
-        - `RoomHandle.on_new_connection` callback.
+       - `RoomHandle.on_new_connection` callback.
     - Handling of RPC events:
         - `PeerCreated`;
         - `SdpAnswerMade`;
@@ -625,30 +559,20 @@ See [
         - `Jason.on_local_stream` callback.
 
 [#18]: https://github.com/instrumentisto/medea/pull/18
-
 [#20]: https://github.com/instrumentisto/medea/pull/20
-
 [#22]: https://github.com/instrumentisto/medea/pull/22
 
 
+
+
 [Cargo features]: https://doc.rust-lang.org/cargo/reference/features.html
-
 [Flutter]: https://flutter.dev
-
 [MSRV]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field
-
 [SFU]: https://webrtcglossary.com/sfu
-
 [Semantic Versioning 2.0.0]: https://semver.org
-
 [VP9]: https://bloggeek.me/webrtcglossary/vp9
-
 [`derive_more`]: https://docs.rs/derive_more
-
 [`flutter_rust_bridge`]: https://docs.rs/flutter_rust_bridge
-
 [`medea-client-api-proto`]: https://docs.rs/medea-client-api-proto
-
 [`talc`]: https://docs.rs/talc
-
 [`wee_alloc`]: https://docs.rs/wee_alloc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## master
+
+[Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.11.0...master)
+
+### Changed
+
+- `ConnectionHandle.onQualityScoreUpdate()` callback is no longer being called when `Connection` is in `SFU` mode. ([#228])
+
+[#228]: https://github.com/instrumentisto/medea-jason/pull/228
+
+
+
+
 ## [0.11.0] · 2025-07-17
 [0.11.0]: https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.11.0
 
@@ -40,10 +53,6 @@ See also [`medea_jason` pub package 0.11.0 changes](https://github.com/instrumen
     - `LocalMediaTrack.setAutoGainControlEnabled()`, `LocalMediaTrack.isAutoGainControlEnabled()` to inspect and toggle auto gain control (supported on web and desktop platforms).
     - `LocalMediaTrack.setNoiseSuppressionLevel()`, `LocalMediaTrack.getNoiseSuppressionLevel()` to inspect and configure noise suppression level (only supported on desktop platforms).
     - `LocalMediaTrack.setHighPassFilterEnabled()`, `LocalMediaTrack.isHighPassFilterEnabledO()` to inspect and toggle high-pass filter (only supported on desktop platforms).
-
-### Changed
-
-- `ConnectionHandle.onQualityScoreUpdate()` callback now receives `0` quality score if peer is disconnected. ([#212])
 
 [#206]: https://github.com/instrumentisto/medea-jason/pull/206
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,28 +3,25 @@
 
 All user visible changes to this project will be documented in this file. This project uses [Semantic Versioning 2.0.0].
 
-
-
-
 ## master
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.11.0...master)
 
 ### Changed
 
-- `ConnectionHandle.onQualityScoreUpdate()` callback is no longer being called when `Connection` is in `SFU` mode. ([#228])
+- `ConnectionHandle.onQualityScoreUpdate()` callback now is being called with `ConnectionQualityScore::High` when
+  `Connection` is in `SFU` mode. ([#228])
 
 [#228]: https://github.com/instrumentisto/medea-jason/pull/228
 
-
-
-
 ## [0.11.0] · 2025-07-17
+
 [0.11.0]: https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.11.0
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.10.0...medea-jason-0.11.0)
 
-See also [`medea_jason` pub package 0.11.0 changes](https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.11.0/flutter/CHANGELOG.md).
+See also [
+`medea_jason` pub package 0.11.0 changes](https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.11.0/flutter/CHANGELOG.md).
 
 ### Changed
 
@@ -32,10 +29,8 @@ See also [`medea_jason` pub package 0.11.0 changes](https://github.com/instrumen
 
 [#212]: https://github.com/instrumentisto/medea-jason/pull/212
 
-
-
-
 ## [0.10.0] · 2025-07-05
+
 [0.10.0]: https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.10.0
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.9.1...medea-jason-0.10.0)
@@ -43,33 +38,38 @@ See also [`medea_jason` pub package 0.11.0 changes](https://github.com/instrumen
 ### Added
 
 - Options to configure audio processing when creating local audio track: ([#206])
-    - `AudioTrackConstraints.exactEchoCancellation`, `AudioTrackConstraints.idealEchoCancellation` to configure echo cancellation.
-    - `AudioTrackConstraints.exactNoiseSuppression`, `AudioTrackConstraints.idealNoiseSuppression`, `AudioTrackConstraints.noiseSuppressionLevel` to configure noise suppression.
-    - `AudioTrackConstraints.exactHighPassFilter`, `AudioTrackConstraints.idealHighPassFilter` to configure high-pass filter.
+    - `AudioTrackConstraints.exactEchoCancellation`, `AudioTrackConstraints.idealEchoCancellation` to configure echo
+      cancellation.
+    - `AudioTrackConstraints.exactNoiseSuppression`, `AudioTrackConstraints.idealNoiseSuppression`,
+      `AudioTrackConstraints.noiseSuppressionLevel` to configure noise suppression.
+    - `AudioTrackConstraints.exactHighPassFilter`, `AudioTrackConstraints.idealHighPassFilter` to configure high-pass
+      filter.
 - Ability to inspect and configure audio processing for a audio `LocalMediaTrack` in runtime: ([#206])
     - `LocalMediaTrack.isAudioProcessingAvailable()` indicating if audio processing is available.
-    - `LocalMediaTrack.setNoiseSuppressionEnabled()`, `LocalMediaTrack.isNoiseSuppressionEnabled()` to inspect and toggle noise suppression (supported on web and desktop platforms).
-    - `LocalMediaTrack.setEchoCancellationEnabled()`, `LocalMediaTrack.isEchoCancellationEnabled()` to inspect and toggle echo cancellation (supported on web and desktop platforms).
-    - `LocalMediaTrack.setAutoGainControlEnabled()`, `LocalMediaTrack.isAutoGainControlEnabled()` to inspect and toggle auto gain control (supported on web and desktop platforms).
-    - `LocalMediaTrack.setNoiseSuppressionLevel()`, `LocalMediaTrack.getNoiseSuppressionLevel()` to inspect and configure noise suppression level (only supported on desktop platforms).
-    - `LocalMediaTrack.setHighPassFilterEnabled()`, `LocalMediaTrack.isHighPassFilterEnabledO()` to inspect and toggle high-pass filter (only supported on desktop platforms).
+    - `LocalMediaTrack.setNoiseSuppressionEnabled()`, `LocalMediaTrack.isNoiseSuppressionEnabled()` to inspect and
+      toggle noise suppression (supported on web and desktop platforms).
+    - `LocalMediaTrack.setEchoCancellationEnabled()`, `LocalMediaTrack.isEchoCancellationEnabled()` to inspect and
+      toggle echo cancellation (supported on web and desktop platforms).
+    - `LocalMediaTrack.setAutoGainControlEnabled()`, `LocalMediaTrack.isAutoGainControlEnabled()` to inspect and toggle
+      auto gain control (supported on web and desktop platforms).
+    - `LocalMediaTrack.setNoiseSuppressionLevel()`, `LocalMediaTrack.getNoiseSuppressionLevel()` to inspect and
+      configure noise suppression level (only supported on desktop platforms).
+    - `LocalMediaTrack.setHighPassFilterEnabled()`, `LocalMediaTrack.isHighPassFilterEnabledO()` to inspect and toggle
+      high-pass filter (only supported on desktop platforms).
 
 [#206]: https://github.com/instrumentisto/medea-jason/pull/206
 
-
-
-
 ## [0.9.1] · 2025-04-11
+
 [0.9.1]: https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.9.1
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.9.0...medea-jason-0.9.1)
 
-See [`medea_jason` pub package 0.9.1 changes](https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.9.1/flutter/CHANGELOG.md).
-
-
-
+See [
+`medea_jason` pub package 0.9.1 changes](https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.9.1/flutter/CHANGELOG.md).
 
 ## [0.9.0] · 2025-03-29
+
 [0.9.0]: https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.9.0
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.8.0...medea-jason-0.9.0)
@@ -82,7 +82,8 @@ See [`medea_jason` pub package 0.9.1 changes](https://github.com/instrumentisto/
 
 - Support of changing `RTCRtpSendParameters.encodings` via `Event::PeerUpdated`. ([#199])
 - Providing user agent media capabilities via `Command::JoinRoom`. ([#199])
-- `LocalMediaTrack.is_on_audio_level_available()` and `LocalMediaTrack.on_audio_level_changed()` support on Web. ([#202], [#97], [#167])
+- `LocalMediaTrack.is_on_audio_level_available()` and `LocalMediaTrack.on_audio_level_changed()` support on
+  Web. ([#202], [#97], [#167])
 
 ### Fixed
 
@@ -94,13 +95,13 @@ See [`medea_jason` pub package 0.9.1 changes](https://github.com/instrumentisto/
     - Upgraded [`flutter_rust_bridge`] crate to 2.9.0 version. ([#203])
 
 [#199]: https://github.com/instrumentisto/medea-jason/pull/199
+
 [#202]: https://github.com/instrumentisto/medea-jason/pull/202
+
 [#203]: https://github.com/instrumentisto/medea-jason/pull/203
 
-
-
-
 ## [0.8.0] · 2025-03-10
+
 [0.8.0]: https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.8.0
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.7.1...medea-jason-0.8.0)
@@ -120,15 +121,17 @@ See [`medea_jason` pub package 0.9.1 changes](https://github.com/instrumentisto/
 - Segfault when closing [Flutter] application on macOS. ([#201])
 
 [#200]: https://github.com/instrumentisto/medea-jason/pull/200
+
 [#201]: https://github.com/instrumentisto/medea-jason/pull/200
+
 [3ed7d2bf]: https://github.com/instrumentisto/medea-jason/commit/3ed7d2bf59ed1237d9e55c4b65ea5cad833306fa
+
 [6f760c83]: https://github.com/instrumentisto/medea-jason/commit/6f760c836f9c5293b5fefae8a0cb4ee2bd5cfda2
+
 [080-1]: https://doc.rust-lang.org/edition-guide/rust-2024/index.html
 
-
-
-
 ## [0.7.1] · 2024-12-30
+
 [0.7.1]: https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.7.1
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.7.0...medea-jason-0.7.1)
@@ -143,12 +146,11 @@ See [`medea_jason` pub package 0.9.1 changes](https://github.com/instrumentisto/
     - [`flutter_rust_bridge`] to 2.7.0 version. ([#195])
 
 [#195]: https://github.com/instrumentisto/medea-jason/pull/195
+
 [#197]: https://github.com/instrumentisto/medea-jason/pull/197
 
-
-
-
 ## [0.7.0] · 2024-10-29
+
 [0.7.0]: https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.7.0
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.6.1...medea-jason-0.7.0)
@@ -169,12 +171,11 @@ See [`medea_jason` pub package 0.9.1 changes](https://github.com/instrumentisto/
     - [`flutter_rust_bridge`] to 2.4.0 version. ([#188])
 
 [#187]: https://github.com/instrumentisto/medea-jason/pull/187
+
 [#188]: https://github.com/instrumentisto/medea-jason/pull/188
 
-
-
-
 ## [0.6.1] · 2024-09-11
+
 [0.6.1]: https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.6.1
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.6.0...medea-jason-0.6.1)
@@ -185,10 +186,8 @@ See [`medea_jason` pub package 0.9.1 changes](https://github.com/instrumentisto/
 
 [fe29ee20]: https://github.com/instrumentisto/medea-jason/commit/fe29ee20b7dd210145a2004ebe8389140aec10a3
 
-
-
-
 ## [0.6.0] · 2024-08-27
+
 [0.6.0]: https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.6.0
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.5.0...medea-jason-0.6.0)
@@ -204,13 +203,13 @@ See [`medea_jason` pub package 0.9.1 changes](https://github.com/instrumentisto/
     - [`flutter_rust_bridge`] to 2.2.0 version. ([#182])
 
 [#180]: https://github.com/instrumentisto/medea-jason/pull/180
+
 [#181]: https://github.com/instrumentisto/medea-jason/pull/181
+
 [#182]: https://github.com/instrumentisto/medea-jason/pull/182
 
-
-
-
 ## [0.5.0] · 2024-08-05
+
 [0.5.0]: https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.5.0
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.4.0...medea-jason-0.5.0)
@@ -219,7 +218,8 @@ See [`medea_jason` pub package 0.9.1 changes](https://github.com/instrumentisto/
 
 - Minimal supported version of [`medea-client-api-proto`] is `0.6.0` ([#151]).
 - Library API:
-    - Removed `with_rpc_client()` constructor and added `WebSocketRpcClient` as argument to `new()` constructor in `Jason` ([#175]).
+    - Removed `with_rpc_client()` constructor and added `WebSocketRpcClient` as argument to `new()` constructor in
+      `Jason` ([#175]).
 
 ### Added
 
@@ -242,20 +242,27 @@ See [`medea_jason` pub package 0.9.1 changes](https://github.com/instrumentisto/
 - Exception in Dart code might be ignored by Rust caller ([#176]).
 
 [#135]: https://github.com/instrumentisto/medea-jason/pull/135
+
 [#138]: https://github.com/instrumentisto/medea-jason/pull/138
+
 [#151]: https://github.com/instrumentisto/medea-jason/pull/151
+
 [#162]: https://github.com/instrumentisto/medea-jason/pull/162
+
 [#163]: https://github.com/instrumentisto/medea-jason/pull/163
+
 [#166]: https://github.com/instrumentisto/medea-jason/pull/166
+
 [#167]: https://github.com/instrumentisto/medea-jason/pull/167
+
 [#172]: https://github.com/instrumentisto/medea-jason/pull/172
+
 [#175]: https://github.com/instrumentisto/medea-jason/pull/175
+
 [#176]: https://github.com/instrumentisto/medea-jason/pull/176
 
-
-
-
 ## [0.4.0] · 2023-07-11
+
 [0.4.0]: https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.4.0
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.3.0...medea-jason-0.4.0)
@@ -271,10 +278,8 @@ See [`medea_jason` pub package 0.9.1 changes](https://github.com/instrumentisto/
 
 [#119]: https://github.com/instrumentisto/medea-jason/pull/119
 
-
-
-
 ## [0.3.0] · 2023-06-09
+
 [0.3.0]: https://github.com/instrumentisto/medea-jason/tree/medea-jason-0.3.0
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/a2ce6b92...medea-jason-0.3.0)
@@ -282,7 +287,8 @@ See [`medea_jason` pub package 0.9.1 changes](https://github.com/instrumentisto/
 ### BC Breaks
 
 - Library API:
-    - `ReconnectHandle.reconnect_with_backoff()` now performs first reconnect attempt immediately ([instrumentisto/medea#206]).
+    - `ReconnectHandle.reconnect_with_backoff()` now performs first reconnect attempt
+      immediately ([instrumentisto/medea#206]).
     - Removed `JasonError` and changed thrown exceptions kind ([#4]):
         - `ConnectionHandle`:
             - `on_close` - `StateError`;
@@ -330,7 +336,8 @@ See [`medea_jason` pub package 0.9.1 changes](https://github.com/instrumentisto/
         - `MediaStateTransitionException`;
         - `MediaSettingsUpdateException`.
     - `MediaManagerHandle.set_output_audio_id()` method switching output audio device on Dart platform ([#29]);
-    - `MediaManagerHandle.on_device_change()` callback firing whenever `MediaManagerHandle.enumerate_devices()` list changes ([#30]);
+    - `MediaManagerHandle.on_device_change()` callback firing whenever `MediaManagerHandle.enumerate_devices()` list
+      changes ([#30]);
     - `ConnectionHandle` methods ([#43], [#59]):
         - `enable_remote_video`;
         - `disable_remote_video`;
@@ -360,32 +367,51 @@ See [`medea_jason` pub package 0.9.1 changes](https://github.com/instrumentisto/
 - Switch to [2021 Rust edition][012-1] ([#16]).
 
 [instrumentisto/medea#206]: https://github.com/instrumentisto/medea/pull/206
+
 [#4]: https://github.com/instrumentisto/medea-jason/pull/4
+
 [#8]: https://github.com/instrumentisto/medea-jason/pull/8
+
 [#9]: https://github.com/instrumentisto/medea-jason/pull/9
+
 [#10]: https://github.com/instrumentisto/medea-jason/pull/10
+
 [#12]: https://github.com/instrumentisto/medea-jason/pull/12
+
 [#14]: https://github.com/instrumentisto/medea-jason/pull/14
+
 [#16]: https://github.com/instrumentisto/medea-jason/pull/16
+
 [#26]: https://github.com/instrumentisto/medea-jason/pull/26
+
 [#28]: https://github.com/instrumentisto/medea-jason/pull/28
+
 [#29]: https://github.com/instrumentisto/medea-jason/pull/29
+
 [#30]: https://github.com/instrumentisto/medea-jason/pull/30
+
 [#31]: https://github.com/instrumentisto/medea-jason/pull/31
+
 [#43]: https://github.com/instrumentisto/medea-jason/pull/43
+
 [#46]: https://github.com/instrumentisto/medea-jason/pull/46
+
 [#49]: https://github.com/instrumentisto/medea-jason/pull/49
+
 [#52]: https://github.com/instrumentisto/medea-jason/pull/52
+
 [#57]: https://github.com/instrumentisto/medea-jason/pull/57
+
 [#59]: https://github.com/instrumentisto/medea-jason/pull/59
+
 [#81]: https://github.com/instrumentisto/medea-jason/pull/81
+
 [#106]: https://github.com/instrumentisto/medea-jason/pull/106
+
 [#106]: https://github.com/instrumentisto/medea-jason/pull/109
 
-
-
-
 ## [0.2.0] · 2021-04-09
+
 [0.2.0]: https://github.com/instrumentisto/medea/tree/medea-jason-0.2.0/jason
 
 [Diff](https://github.com/instrumentisto/medea/compare/medea-jason-0.1.0...medea-jason-0.2.0) | [Milestone](https://github.com/instrumentisto/medea/milestone/2) | [Roadmap](https://github.com/instrumentisto/medea/issues/27)
@@ -417,7 +443,8 @@ See [`medea_jason` pub package 0.9.1 changes](https://github.com/instrumentisto/
         - Local media stream constraints:
             - `MediaStreamSettings`, `AudioTrackConstraints` classes ([#46], [#97]);
             - `DeviceVideoTrackConstraints`, `DisplayVideoTrackConstraints` classes ([#78]);
-            - `DeviceVideoTrackConstraints.ideal_facing_mode` and `DeviceVideoTrackConstraints.exact_facing_mode` functions ([#137]);
+            - `DeviceVideoTrackConstraints.ideal_facing_mode` and `DeviceVideoTrackConstraints.exact_facing_mode`
+              functions ([#137]);
             - `DeviceVideoTrackConstraints` width and height configuration ([#158]):
                 - `DeviceVideoTrackConstraints.ideal_width`;
                 - `DeviceVideoTrackConstraints.exact_width`;
@@ -432,16 +459,22 @@ See [`medea_jason` pub package 0.9.1 changes](https://github.com/instrumentisto/
             - `Jason.init_room()` ([#46]);
             - `Room.join()` ([#46]);
             - `Jason.close_room()` ([#147]).
-        - Ability to configure local media stream used by `Room` via `Room.set_local_media_settings()` ([#54], [#97], [#145], [#160]):
-            - `Room.set_local_media_settings()` can be configured to stop used tracks before trying to acquire new tracks ([#160]);
-            - `Room.set_local_media_settings()` can be configured to rollback to previous settings if fail to set new settings ([#160]).
+        - Ability to configure local media stream used by `Room` via
+          `Room.set_local_media_settings()` ([#54], [#97], [#145], [#160]):
+            - `Room.set_local_media_settings()` can be configured to stop used tracks before trying to acquire new
+              tracks ([#160]);
+            - `Room.set_local_media_settings()` can be configured to rollback to previous settings if fail to set new
+              settings ([#160]).
         - `Room.on_failed_local_media` callback ([#54], [#143]);
         - `Room.on_close` callback for WebSocket close initiated by server ([#55]);
-        - `RemoteMediaTrack.on_enabled` and `RemoteMediaTrack.on_disabled` callbacks being called when `RemoteMediaTrack` is enabled or disabled ([#123], [#143], [#156]);
+        - `RemoteMediaTrack.on_enabled` and `RemoteMediaTrack.on_disabled` callbacks being called when
+          `RemoteMediaTrack` is enabled or disabled ([#123], [#143], [#156]);
         - `RemoteMediaTrack.on_stopped` callback that is called when `RemoteMediaTrack` is stopped ([#109]);
-        - `RemoteMediaTrack.on_muted` and `RemoteMediaTrack.on_unmuted` callbacks being called when `RemoteMediaTrack` is muted or unmuted ([#191]);
+        - `RemoteMediaTrack.on_muted` and `RemoteMediaTrack.on_unmuted` callbacks being called when `RemoteMediaTrack`
+          is muted or unmuted ([#191]);
         - `RemoteMediaTrack.muted()` method indicating whether this `RemoteMediaTrack` is muted ([#191]);
-        - `ConnectionHandle.on_remote_track_added` callback being called when new receiver `RemoteMediaTrack` is added ([#123], [#143], [#156]);
+        - `ConnectionHandle.on_remote_track_added` callback being called when new receiver `RemoteMediaTrack` is
+          added ([#123], [#143], [#156]);
         - Enabling/disabling remote video/audio ([#127], [#155]):
             - `Room.disable_remote_audio`;
             - `Room.enable_remote_audio`;
@@ -476,7 +509,8 @@ See [`medea_jason` pub package 0.9.1 changes](https://github.com/instrumentisto/
         - Enabling/disabling audio/video send/receive via `UpdateTracks` command ([#81], [#155]);
         - Muting/unmuting audio/video send via `UpdateTracks` ([#156]).
     - Handling of RPC events:
-        - `PeerUpdated` with `PeerUpdate::Added`, `PeerUpdate::Updated`, `PeerUpdate::IceRestart` and `PeerUpdate::Removed` ([#105], [#138], [#139], [#109]);
+        - `PeerUpdated` with `PeerUpdate::Added`, `PeerUpdate::Updated`, `PeerUpdate::IceRestart` and
+          `PeerUpdate::Removed` ([#105], [#138], [#139], [#109]);
         - `ConnectionQualityUpdated` ([#132]).
 - Error handling:
     - Library API:
@@ -488,45 +522,77 @@ See [`medea_jason` pub package 0.9.1 changes](https://github.com/instrumentisto/
     - Skipped `IceCandidate`s received before receiving remote SDP ([#50]).
 
 [#40]: https://github.com/instrumentisto/medea/pull/40
+
 [#46]: https://github.com/instrumentisto/medea/pull/46
+
 [#50]: https://github.com/instrumentisto/medea/pull/59
+
 [#54]: https://github.com/instrumentisto/medea/pull/54
+
 [#55]: https://github.com/instrumentisto/medea/pull/55
+
 [#71]: https://github.com/instrumentisto/medea/pull/71
+
 [#75]: https://github.com/instrumentisto/medea/pull/75
+
 [#78]: https://github.com/instrumentisto/medea/pull/78
+
 [#79]: https://github.com/instrumentisto/medea/pull/79
+
 [#81]: https://github.com/instrumentisto/medea/pull/81
+
 [#87]: https://github.com/instrumentisto/medea/pull/87
+
 [#90]: https://github.com/instrumentisto/medea/pull/90
+
 [#97]: https://github.com/instrumentisto/medea/pull/97
+
 [#105]: https://github.com/instrumentisto/medea/pull/105
+
 [#106]: https://github.com/instrumentisto/medea/pull/106
+
 [#109]: https://github.com/instrumentisto/medea/pull/109
+
 [#120]: https://github.com/instrumentisto/medea/pull/120
+
 [#123]: https://github.com/instrumentisto/medea/pull/123
+
 [#124]: https://github.com/instrumentisto/medea/pull/124
+
 [#127]: https://github.com/instrumentisto/medea/pull/127
+
 [#132]: https://github.com/instrumentisto/medea/pull/132
+
 [#137]: https://github.com/instrumentisto/medea/pull/137
+
 [#138]: https://github.com/instrumentisto/medea/pull/138
+
 [#139]: https://github.com/instrumentisto/medea/pull/139
+
 [#143]: https://github.com/instrumentisto/medea/pull/143
+
 [#144]: https://github.com/instrumentisto/medea/pull/144
+
 [#145]: https://github.com/instrumentisto/medea/pull/145
+
 [#146]: https://github.com/instrumentisto/medea/pull/146
+
 [#147]: https://github.com/instrumentisto/medea/pull/147
+
 [#155]: https://github.com/instrumentisto/medea/pull/155
+
 [#156]: https://github.com/instrumentisto/medea/pull/156
+
 [#158]: https://github.com/instrumentisto/medea/pull/158
+
 [#160]: https://github.com/instrumentisto/medea/pull/160
+
 [#167]: https://github.com/instrumentisto/medea/pull/167
+
 [#191]: https://github.com/instrumentisto/medea/pull/191
 
-
-
-
 ## [0.1.0] · 2019-08-21
+
 [0.1.0]: https://github.com/instrumentisto/medea/tree/medea-jason-0.1.0/jason
 
 [Milestone](https://github.com/instrumentisto/medea/milestone/1) | [Roadmap](https://github.com/instrumentisto/medea/issues/8)
@@ -542,7 +608,7 @@ See [`medea_jason` pub package 0.9.1 changes](https://github.com/instrumentisto/
 - Ability to use ICE servers provided by server ([#20]).
 - Signalling ([#22]):
     - Library API:
-       - `RoomHandle.on_new_connection` callback.
+        - `RoomHandle.on_new_connection` callback.
     - Handling of RPC events:
         - `PeerCreated`;
         - `SdpAnswerMade`;
@@ -559,20 +625,30 @@ See [`medea_jason` pub package 0.9.1 changes](https://github.com/instrumentisto/
         - `Jason.on_local_stream` callback.
 
 [#18]: https://github.com/instrumentisto/medea/pull/18
+
 [#20]: https://github.com/instrumentisto/medea/pull/20
+
 [#22]: https://github.com/instrumentisto/medea/pull/22
 
 
-
-
 [Cargo features]: https://doc.rust-lang.org/cargo/reference/features.html
+
 [Flutter]: https://flutter.dev
+
 [MSRV]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field
+
 [SFU]: https://webrtcglossary.com/sfu
+
 [Semantic Versioning 2.0.0]: https://semver.org
+
 [VP9]: https://bloggeek.me/webrtcglossary/vp9
+
 [`derive_more`]: https://docs.rs/derive_more
+
 [`flutter_rust_bridge`]: https://docs.rs/flutter_rust_bridge
+
 [`medea-client-api-proto`]: https://docs.rs/medea-client-api-proto
+
 [`talc`]: https://docs.rs/talc
+
 [`wee_alloc`]: https://docs.rs/wee_alloc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ All user visible changes to this project will be documented in this file. This p
 
 [Diff](https://github.com/instrumentisto/medea-jason/compare/medea-jason-0.11.0...master)
 
-### Changed
+### Fixed
 
-- `ConnectionHandle.onQualityScoreUpdate()` callback is no longer being called when `Connection` is in `SFU` mode. ([#228])
+- `ConnectionHandle.onQualityScoreUpdate()` callback being called when `Connection` is in [SFU] mode. ([#228])
 
 [#228]: https://github.com/instrumentisto/medea-jason/pull/228
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All user visible changes to this project will be documented in this file. This p
 
 ### Changed
 
-- `ConnectionHandle.onQualityScoreUpdate()` callback now is being called with `ConnectionQualityScore::High` when `Connection` is in `SFU` mode. ([#228])
+- `ConnectionHandle.onQualityScoreUpdate()` callback is no longer being called when `Connection` is in `SFU` mode. ([#228])
 
 [#228]: https://github.com/instrumentisto/medea-jason/pull/228
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -365,8 +365,8 @@ struct InnerConnection {
     /// Callback invoked when a [`ConnectionQualityScore`] is updated.
     on_quality_score_update: platform::Callback<u8>,
 
-    /// Indicator whether this `Connection` is working in a [P2P mesh] or [SFU]
-    /// mode.
+    /// Indicator whether this [`Connection`] is working in a [P2P mesh] or
+    /// [SFU] mode.
     ///
     /// [P2P mesh]: https://webrtcglossary.com/mesh
     /// [SFU]: https://webrtcglossary.com/sfu
@@ -733,8 +733,9 @@ impl Connection {
         use PeerConnectionState as S;
 
         match self.0.connection_mode {
-            // `on_quality_score_update()` isn't implemented for `SFU` mode.
-            // See `instrumentisto/medea-jason#227`.
+            // `on_quality_score_update()` isn't implemented for SFU mode.
+            // See instrumentisto/medea-jason#227 for the details:
+            // https://github.com/instrumentisto/medea-jason/issues/227
             ConnectionMode::Sfu => return,
             ConnectionMode::Mesh => (),
         }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -498,7 +498,8 @@ impl ConnectionHandle {
                 inner.on_quality_score_update.set_func(f);
 
                 if inner.connection_mode == ConnectionMode::Sfu {
-                    // `on_quality_score_update()` isn't implemented for `SFU` mode.
+                    // `on_quality_score_update()` isn't implemented for `SFU`
+                    // mode.
                     // So we are manually refreshing quality score.
                     // See `instrumentisto/medea-jason#227`.
                     Connection(inner).refresh_client_conn_quality_score();

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -111,7 +111,6 @@ impl Connections {
         track_id: &TrackId,
         partner_members: HashSet<MemberId>,
         connection_mode: ConnectionMode,
-        peer_state: PeerConnectionState,
     ) -> Vec<Connection> {
         if let Some(partners) =
             self.tracks_to_members.borrow_mut().get_mut(track_id)
@@ -146,7 +145,6 @@ impl Connections {
                         mid.clone(),
                         &self.room_recv_constraints,
                         connection_mode,
-                        peer_state,
                     );
                     self.on_new_connection.call1(connection.new_handle());
                     drop(connections.insert(mid.clone(), connection));
@@ -179,12 +177,7 @@ impl Connections {
                 .collect();
         }
 
-        self.add_connections(
-            *track_id,
-            &partner_members,
-            connection_mode,
-            peer_state,
-        )
+        self.add_connections(*track_id, &partner_members, connection_mode)
     }
 
     /// Adds information about related [`Track`]s with the provided [`TrackId`]
@@ -199,7 +192,6 @@ impl Connections {
         track_id: TrackId,
         partner_members: &HashSet<MemberId>,
         connection_mode: ConnectionMode,
-        peer_state: PeerConnectionState,
     ) -> Vec<Connection> {
         let mut connections = self.members_to_conns.borrow_mut();
 
@@ -216,7 +208,6 @@ impl Connections {
                     partner.clone(),
                     &self.room_recv_constraints,
                     connection_mode,
-                    peer_state,
                 );
                 self.on_new_connection.call1(connection.new_handle());
                 drop(connections.insert(partner.clone(), connection));
@@ -493,19 +484,10 @@ impl ConnectionHandle {
         &self,
         f: platform::Function<u8>,
     ) -> Result<(), Traced<HandleDetachedError>> {
-        self.0.upgrade().ok_or_else(|| tracerr::new!(HandleDetachedError)).map(
-            |inner| {
-                inner.on_quality_score_update.set_func(f);
-
-                if inner.connection_mode == ConnectionMode::Sfu {
-                    // `on_quality_score_update()` isn't called for new `SFU`
-                    // connections.
-                    // So we are manually refreshing quality score here.
-                    // See `instrumentisto/medea-jason#227`.
-                    Connection(inner).refresh_client_conn_quality_score();
-                }
-            },
-        )
+        self.0
+            .upgrade()
+            .ok_or_else(|| tracerr::new!(HandleDetachedError))
+            .map(|inner| inner.on_quality_score_update.set_func(f))
     }
 
     /// Enables inbound video in this [`Connection`].
@@ -630,7 +612,6 @@ impl Connection {
         remote_id: MemberId,
         room_recv_constraints: &Rc<RecvConstraints>,
         connection_mode: ConnectionMode,
-        peer_state: PeerConnectionState,
     ) -> Self {
         // Clone initial incoming media constraints.
         let recv_constraints = Rc::new(room_recv_constraints.as_ref().clone());
@@ -659,7 +640,7 @@ impl Connection {
             remote_id,
             quality_score: Cell::default(),
             client_quality_score: Cell::default(),
-            peer_state: Cell::new(Some(peer_state)),
+            peer_state: Cell::default(),
             on_quality_score_update: platform::Callback::default(),
             recv_constraints,
             connection_mode,
@@ -750,23 +731,22 @@ impl Connection {
     fn refresh_client_conn_quality_score(&self) {
         use PeerConnectionState as S;
 
+        match self.0.connection_mode {
+            // `on_quality_score_update()` isn't implemented for `SFU` mode.
+            // See `instrumentisto/medea-jason#227`.
+            ConnectionMode::Sfu => return,
+            ConnectionMode::Mesh => (),
+        }
+
         let state = self.0.peer_state.get();
         let quality_score = self.0.quality_score.get();
         let score = match (state, quality_score) {
             (Some(S::Connected), Some(quality_score)) => quality_score.into(),
-            (Some(S::Connected), None) => match self.0.connection_mode {
-                // `on_quality_score_update()` isn't implemented for `SFU` mode.
-                // So we are manually setting quality score.
-                // See `instrumentisto/medea-jason#227`.
-                ConnectionMode::Sfu => ClientConnectionQualityScore::Connected(
-                    ConnectionQualityScore::High,
-                ),
-                ConnectionMode::Mesh => return,
-            },
             (Some(S::Disconnected | S::Failed | S::Closed), _) => {
                 ClientConnectionQualityScore::Disconnected
             }
-            (Some(S::Connecting | S::New) | None, _) => return,
+            (Some(S::Connecting | S::New) | None, _)
+            | (Some(S::Connected), None) => return,
         };
 
         let is_score_changed =

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -498,9 +498,9 @@ impl ConnectionHandle {
                 inner.on_quality_score_update.set_func(f);
 
                 if inner.connection_mode == ConnectionMode::Sfu {
-                    // `on_quality_score_update()` isn't implemented for `SFU`
-                    // mode.
-                    // So we are manually refreshing quality score.
+                    // `on_quality_score_update()` isn't called for new `SFU`
+                    // connections.
+                    // So we are manually refreshing quality score here.
                     // See `instrumentisto/medea-jason#227`.
                     Connection(inner).refresh_client_conn_quality_score();
                 }
@@ -756,7 +756,7 @@ impl Connection {
             (Some(S::Connected), Some(quality_score)) => quality_score.into(),
             (Some(S::Connected), None) => match self.0.connection_mode {
                 // `on_quality_score_update()` isn't implemented for `SFU` mode.
-                // So we are manually refreshing quality score.
+                // So we are manually setting quality score.
                 // See `instrumentisto/medea-jason#227`.
                 ConnectionMode::Sfu => ClientConnectionQualityScore::Connected(
                     ConnectionQualityScore::High,

--- a/src/peer/component/watchers.rs
+++ b/src/peer/component/watchers.rs
@@ -163,6 +163,7 @@ impl Component {
             &track_id,
             new_sender.receivers().into_iter().collect(),
             state.connection_mode,
+            peer.peer.connection_state(),
         ));
         let sender = sender::Sender::new(
             &new_sender,
@@ -203,6 +204,7 @@ impl Component {
             &track_id,
             HashSet::from([rcvr_state.sender_id().clone()]),
             state.connection_mode,
+            peer.peer.connection_state(),
         );
         let receiver = receiver::Receiver::new(
             &rcvr_state,
@@ -236,6 +238,7 @@ impl Component {
             &val.0,
             val.1,
             state.connection_mode,
+            peer.peer.connection_state(),
         ));
 
         state.maybe_update_connections.set(None);

--- a/src/peer/component/watchers.rs
+++ b/src/peer/component/watchers.rs
@@ -163,7 +163,6 @@ impl Component {
             &track_id,
             new_sender.receivers().into_iter().collect(),
             state.connection_mode,
-            peer.peer.connection_state(),
         ));
         let sender = sender::Sender::new(
             &new_sender,
@@ -204,7 +203,6 @@ impl Component {
             &track_id,
             HashSet::from([rcvr_state.sender_id().clone()]),
             state.connection_mode,
-            peer.peer.connection_state(),
         );
         let receiver = receiver::Receiver::new(
             &rcvr_state,
@@ -238,7 +236,6 @@ impl Component {
             &val.0,
             val.1,
             state.connection_mode,
-            peer.peer.connection_state(),
         ));
 
         state.maybe_update_connections.set(None);

--- a/src/peer/component/watchers.rs
+++ b/src/peer/component/watchers.rs
@@ -162,6 +162,7 @@ impl Component {
         drop(peer.connections.update_connections(
             &track_id,
             new_sender.receivers().into_iter().collect(),
+            state.connection_mode,
         ));
         let sender = sender::Sender::new(
             &new_sender,
@@ -201,6 +202,7 @@ impl Component {
         let conns = peer.connections.update_connections(
             &track_id,
             HashSet::from([rcvr_state.sender_id().clone()]),
+            state.connection_mode,
         );
         let receiver = receiver::Receiver::new(
             &rcvr_state,
@@ -230,7 +232,11 @@ impl Component {
         state: &State,
         val: (TrackId, HashSet<MemberId>),
     ) {
-        drop(peer.connections.update_connections(&val.0, val.1));
+        drop(peer.connections.update_connections(
+            &val.0,
+            val.1,
+            state.connection_mode,
+        ));
 
         state.maybe_update_connections.set(None);
     }


### PR DESCRIPTION
Resolves #227

## Synopsis

`on_quality_score_update()` should never be called when `Connection` is in `SFU` mode because it's not implemented on the server side.

## Solution

`InnerConnection` will remember `ConnectionMode` of its peer and skip refreshing `ClientConnectionQualityScore` if it's in `SFU` mode.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
